### PR TITLE
Fix asyncio hlapi double awaitable returns (Fix #19)

### DIFF
--- a/examples/hlapi/asyncio/agent/ntforg/default-v1-trap.py
+++ b/examples/hlapi/asyncio/agent/ntforg/default-v1-trap.py
@@ -26,7 +26,7 @@ from pysnmp.hlapi.asyncio import *
 
 async def run():
     snmpEngine = SnmpEngine()
-    trap_result = await sendNotification(
+    errorIndication, errorStatus, errorIndex, varBinds = await sendNotification(
         snmpEngine,
         CommunityData('public', mpModel=0),
         UdpTransportTarget(('demo.pysnmp.com', 162)),
@@ -37,7 +37,7 @@ async def run():
             ("1.3.6.1.2.1.1.1.0", OctetString("my system")),
         ),
     )
-    errorIndication, errorStatus, errorIndex, varBinds = await trap_result
+
     if errorIndication:
         print(errorIndication)
 

--- a/examples/hlapi/asyncio/agent/ntforg/multiple-notifications-at-once.py
+++ b/examples/hlapi/asyncio/agent/ntforg/multiple-notifications-at-once.py
@@ -28,7 +28,7 @@ from pysnmp.hlapi.asyncio import *
 
 
 async def sendone(snmpEngine, hostname, notifyType):
-    trap_result = await sendNotification(
+    errorIndication, errorStatus, errorIndex, varBinds = await sendNotification(
         snmpEngine,
         CommunityData("public", tag=hostname),
         UdpTransportTarget((hostname, 162), tagList=hostname),
@@ -39,7 +39,6 @@ async def sendone(snmpEngine, hostname, notifyType):
         ),
     )
 
-    (errorIndication, errorStatus, errorIndex, varBinds) = await trap_result
     if errorIndication:
         print(errorIndication)
     elif errorStatus:

--- a/examples/hlapi/asyncio/agent/ntforg/v3-inform.py
+++ b/examples/hlapi/asyncio/agent/ntforg/v3-inform.py
@@ -18,7 +18,7 @@ from pysnmp.hlapi.asyncio.ntforg import sendNotification
 from pysnmp.hlapi.asyncio.transport import UdpTransportTarget
 
 async def run():
-    iterator = await sendNotification(
+    errorIndication, errorStatus, errorIndex, varBinds = await sendNotification(
         SnmpEngine(),
         UsmUserData('usr-md5-des', 'authkey1', 'privkey1'),
         UdpTransportTarget(('demo.pysnmp.com', 162)),
@@ -32,8 +32,6 @@ async def run():
             'SNMPv2-MIB'
         )
     )
-
-    errorIndication, errorStatus, errorIndex, varBinds = await iterator
 
     if errorIndication:
         print(errorIndication)

--- a/examples/hlapi/asyncio/manager/cmdgen/custom-asn1-mib-search-path.py
+++ b/examples/hlapi/asyncio/manager/cmdgen/custom-asn1-mib-search-path.py
@@ -20,7 +20,7 @@ from pysnmp.hlapi.asyncio import *
 
 async def run():
     snmpEngine = SnmpEngine()
-    get_result = await getCmd(
+    errorIndication, errorStatus, errorIndex, varBinds = await getCmd(
         snmpEngine,
         CommunityData('public'),
         UdpTransportTarget(('demo.pysnmp.com', 161)),
@@ -29,7 +29,6 @@ async def run():
                                                                                 'https://mibs.pysnmp.com/asn1/@mib@'))
     )
 
-    errorIndication, errorStatus, errorIndex, varBinds = await get_result
     if errorIndication:
         print(errorIndication)
     elif errorStatus:

--- a/examples/hlapi/asyncio/manager/cmdgen/getbulk-to-eom.py
+++ b/examples/hlapi/asyncio/manager/cmdgen/getbulk-to-eom.py
@@ -24,7 +24,7 @@ from pysnmp.hlapi.asyncio import *
 async def run(varBinds):
     snmpEngine = SnmpEngine()
     while True:
-        bulk_task = await bulkCmd(
+        errorIndication, errorStatus, errorIndex, varBindTable = await bulkCmd(
             snmpEngine,
             UsmUserData('usr-none-none'),
             UdpTransportTarget(('demo.pysnmp.com', 161)),
@@ -33,7 +33,7 @@ async def run(varBinds):
             50,
             *varBinds
         )
-        (errorIndication, errorStatus, errorIndex, varBindTable) = await bulk_task
+
         if errorIndication:
             print(errorIndication)
             break

--- a/examples/hlapi/asyncio/manager/cmdgen/multiple-sequential-queries.py
+++ b/examples/hlapi/asyncio/manager/cmdgen/multiple-sequential-queries.py
@@ -22,7 +22,7 @@ from pysnmp.hlapi.asyncio import *
 
 
 async def getone(snmpEngine, hostname):
-    result_get = await getCmd(
+    errorIndication, errorStatus, errorIndex, varBinds = await getCmd(
         snmpEngine,
         CommunityData("public"),
         UdpTransportTarget(hostname),
@@ -30,7 +30,6 @@ async def getone(snmpEngine, hostname):
         ObjectType(ObjectIdentity("SNMPv2-MIB", "sysDescr", 0)),
     )
 
-    errorIndication, errorStatus, errorIndex, varBinds = await result_get
     if errorIndication:
         print(errorIndication)
     elif errorStatus:

--- a/examples/hlapi/asyncio/manager/cmdgen/send-trap.py
+++ b/examples/hlapi/asyncio/manager/cmdgen/send-trap.py
@@ -1,0 +1,26 @@
+import asyncio
+from pysnmp.hlapi.asyncio import *
+
+async def run():
+    snmpEngine = SnmpEngine()
+    # Example of how you might update sysUpTime
+    mibBuilder = snmpEngine.msgAndPduDsp.mibInstrumController.mibBuilder
+    sysUpTime, = mibBuilder.importSymbols('__SNMPv2-MIB', 'sysUpTime')
+    sysUpTime.syntax = TimeTicks(12345)  # Set uptime to 12345
+
+    errorIndication, errorStatus, errorIndex, varBinds = await sendNotification(
+        snmpEngine,
+        CommunityData('public', mpModel=0),
+        UdpTransportTarget(('demo.pysnmp.com', 162)),
+        ContextData(),
+        "trap",
+        NotificationType(ObjectIdentity('NET-SNMP-EXAMPLES-MIB', 'netSnmpExampleNotification')).addVarBinds(ObjectType(ObjectIdentity('NET-SNMP-EXAMPLES-MIB','netSnmpExampleHeartbeatRate'), 1))
+    )
+
+    if errorIndication:
+        print(errorIndication)
+
+    snmpEngine.transportDispatcher.closeDispatcher()
+
+
+asyncio.run(run())

--- a/examples/hlapi/asyncio/manager/cmdgen/usm-sha-aes128.py
+++ b/examples/hlapi/asyncio/manager/cmdgen/usm-sha-aes128.py
@@ -29,7 +29,7 @@ from pysnmp.hlapi.asyncio import *
 
 async def run():
     snmpEngine = SnmpEngine()
-    get_result = await getCmd(
+    errorIndication, errorStatus, errorIndex, varBinds = await getCmd(
         snmpEngine,
         UsmUserData('usr-sha-aes', 'authkey1', 'privkey1',
                     authProtocol=usmHMACSHAAuthProtocol,
@@ -38,7 +38,6 @@ async def run():
         ContextData(),
         ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr', 0)))
 
-    errorIndication, errorStatus, errorIndex, varBinds = await get_result
     if errorIndication:
         print(errorIndication)
     elif errorStatus:

--- a/pysnmp/hlapi/asyncio/cmdgen.py
+++ b/pysnmp/hlapi/asyncio/cmdgen.py
@@ -112,14 +112,13 @@ async def getCmd(snmpEngine, authData, transportTarget, contextData,
     >>> from pysnmp.hlapi.asyncio import *
     >>>
     >>> async def run():
-    ...     result_get = await getCmd(
+    ...     errorIndication, errorStatus, errorIndex, varBinds = await getCmd(
     ...         SnmpEngine(),
     ...         CommunityData('public'),
     ...         UdpTransportTarget(('demo.pysnmp.com', 161)),
     ...         ContextData(),
     ...         ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr', 0))
     ...     )
-    ...     errorIndication, errorStatus, errorIndex, varBinds = await result_get
     ...     print(errorIndication, errorStatus, errorIndex, varBinds)
     >>>
     >>> asyncio.run(run())
@@ -156,7 +155,7 @@ async def getCmd(snmpEngine, authData, transportTarget, contextData,
         vbProcessor.makeVarBinds(snmpEngine, varBinds), __cbFun,
         (options.get('lookupMib', True), future)
     )
-    return future
+    return await future
 
 
 async def setCmd(snmpEngine, authData, transportTarget, contextData,
@@ -218,14 +217,13 @@ async def setCmd(snmpEngine, authData, transportTarget, contextData,
     >>> from pysnmp.hlapi.asyncio import *
     >>>
     >>> async def run():
-    ...     set_result = await setCmd(
+    ...     errorIndication, errorStatus, errorIndex, varBinds = await setCmd(
     ...         SnmpEngine(),
     ...         CommunityData('public'),
     ...         UdpTransportTarget(('demo.pysnmp.com', 161)),
     ...         ContextData(),
     ...         ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr', 0), 'Linux i386')
     ...     )
-    ...     errorIndication, errorStatus, errorIndex, varBinds = await set_result
     ...     print(errorIndication, errorStatus, errorIndex, varBinds)
     >>>
     >>> asyncio.run(run())
@@ -262,7 +260,7 @@ async def setCmd(snmpEngine, authData, transportTarget, contextData,
         vbProcessor.makeVarBinds(snmpEngine, varBinds), __cbFun,
         (options.get('lookupMib', True), future)
     )
-    return future
+    return await future
 
 
 async def nextCmd(snmpEngine, authData, transportTarget, contextData,
@@ -328,14 +326,13 @@ async def nextCmd(snmpEngine, authData, transportTarget, contextData,
     >>> from pysnmp.hlapi.asyncio import *
     >>>
     >>> async def run():
-    ...     next_result = await nextCmd(
+    ...     errorIndication, errorStatus, errorIndex, varBinds = await nextCmd(
     ...         SnmpEngine(),
     ...         CommunityData('public'),
     ...         UdpTransportTarget(('demo.pysnmp.com', 161)),
     ...         ContextData(),
     ...         ObjectType(ObjectIdentity('SNMPv2-MIB', 'system'))
     ...     )
-    ...     errorIndication, errorStatus, errorIndex, varBinds = await next_result
     ...     print(errorIndication, errorStatus, errorIndex, varBinds)
     >>>
     >>> asyncio.run(run())
@@ -374,7 +371,7 @@ async def nextCmd(snmpEngine, authData, transportTarget, contextData,
         vbProcessor.makeVarBinds(snmpEngine, varBinds), __cbFun,
         (options.get('lookupMib', True), future)
     )
-    return future
+    return await future
 
 
 async def bulkCmd(snmpEngine, authData, transportTarget, contextData,
@@ -468,7 +465,7 @@ async def bulkCmd(snmpEngine, authData, transportTarget, contextData,
     >>> from pysnmp.hlapi.asyncio import *
     >>>
     >>> async def run():
-    ...     result_bulk = await bulkCmd(
+    ...     errorIndication, errorStatus, errorIndex, varBinds = await bulkCmd(
     ...         SnmpEngine(),
     ...         CommunityData('public'),
     ...         UdpTransportTarget(('demo.pysnmp.com', 161)),
@@ -476,7 +473,6 @@ async def bulkCmd(snmpEngine, authData, transportTarget, contextData,
     ...         0, 2,
     ...         ObjectType(ObjectIdentity('SNMPv2-MIB', 'system'))
     ...     )
-    ...     errorIndication, errorStatus, errorIndex, varBinds = await result_bulk
     ...     print(errorIndication, errorStatus, errorIndex, varBinds)
     >>>
     >>> asyncio.run(run())
@@ -515,4 +511,4 @@ async def bulkCmd(snmpEngine, authData, transportTarget, contextData,
         vbProcessor.makeVarBinds(snmpEngine, varBinds), __cbFun,
         (options.get('lookupMib', True), future)
     )
-    return future
+    return await future

--- a/pysnmp/hlapi/asyncio/ntforg.py
+++ b/pysnmp/hlapi/asyncio/ntforg.py
@@ -101,14 +101,13 @@ async def sendNotification(snmpEngine, authData, transportTarget, contextData,
     >>> from pysnmp.hlapi.asyncio import *
     >>>
     >>> async def run():
-    ...     send_result = await sendNotification(
+    ...     errorIndication, errorStatus, errorIndex, varBinds = await sendNotification(
     ...         SnmpEngine(),
     ...         CommunityData('public'),
     ...         UdpTransportTarget(('demo.pysnmp.com', 162)),
     ...         ContextData(),
     ...         'trap',
     ...         NotificationType(ObjectIdentity('IF-MIB', 'linkDown')))
-    ...     errorIndication, errorStatus, errorIndex, varBinds = await send_result
     ...     print(errorIndication, errorStatus, errorIndex, varBinds)
     ...
     >>> asyncio.run(run())
@@ -159,4 +158,4 @@ async def sendNotification(snmpEngine, authData, transportTarget, contextData,
         loop = asyncio.get_event_loop()
         loop.call_soon(__trapFun, future)
 
-    return future
+    return await future

--- a/pysnmp/hlapi/asyncio/slim.py
+++ b/pysnmp/hlapi/asyncio/slim.py
@@ -105,15 +105,13 @@ class Slim:
 
         """
 
-        get_result = await getCmd(
+        return await getCmd(
             self.snmpEngine,
             CommunityData(communityName, mpModel=self.version - 1),
             UdpTransportTarget((address, port)),
             ContextData(),
             *varBinds,
         )
-
-        return await get_result
 
     async def next(self, communityName, address, port, *varBinds):
         r"""Creates a generator to perform SNMP GETNEXT query.
@@ -180,15 +178,13 @@ class Slim:
 
         """
 
-        next_result = await nextCmd(
+        return await nextCmd(
             self.snmpEngine,
             CommunityData(communityName, mpModel=self.version - 1),
             UdpTransportTarget((address, port)),
             ContextData(),
             *varBinds,
         )
-
-        return await next_result
 
     async def bulk(self, communityName, address, port, nonRepeaters, maxRepetitions, *varBinds):
         r"""Creates a generator to perform SNMP GETBULK query.
@@ -288,7 +284,7 @@ class Slim:
         version = self.version - 1
         if version == 0:
             raise PySnmpError('Cannot send V2 PDU on V1 session')
-        bulk_result = await bulkCmd(
+        return await bulkCmd(
             self.snmpEngine,
             CommunityData(communityName, mpModel=version),
             UdpTransportTarget((address, port)),
@@ -297,8 +293,6 @@ class Slim:
             maxRepetitions,
             *varBinds,
         )
-
-        return await bulk_result
 
     async def set(self, communityName, address, port, *varBinds):
         r"""Creates a generator to perform SNMP SET query.
@@ -361,12 +355,10 @@ class Slim:
 
         """
 
-        set_result = await setCmd(
+        return await setCmd(
             self.snmpEngine,
             CommunityData(communityName, mpModel=self.version - 1),
             UdpTransportTarget((address, port)),
             ContextData(),
             *varBinds,
         )
-
-        return await set_result


### PR DESCRIPTION
Commit 67563a19f028d371efa9683f60eb52908a292b86 introduced a bug while converting legacy asyncio API to new "async def" style.

Previous methods where NOT decorated with @asyncio.coroutine and returned a Future object being awaitable.
Updated code still returns a Future object but adds async keyword to function definition leading to awaitable function returning awaitable Future.

That breaks existing API.