### PR TITLE
Make PySNMP work after 2038

### DIFF
--- a/pysnmp/smi/mibs/SNMP-FRAMEWORK-MIB.py
+++ b/pysnmp/smi/mibs/SNMP-FRAMEWORK-MIB.py
@@ -62,14 +62,14 @@ class SnmpEngineID(TextualConvention, OctetString):
     defaultValue = OctetString(defaultValue).asOctets()
 
 
-class SnmpEngineTime(Integer32):
+class SnmpEngineTime(Unsigned32):
     def clone(self, *args, **kwargs):
         if not args:
             try:
                 args = (time.time() - self,)
             except Exception:
                 pass
-        return Integer32.clone(self, *args, **kwargs)
+        return Unsigned32.clone(self, *args, **kwargs)
 
 
 class SnmpSecurityModel(Integer32, TextualConvention):
@@ -100,7 +100,7 @@ if mibBuilder.loadTexts: snmpEngineID.setDescription("An SNMP engine's administr
 snmpEngineBoots = MibScalar((1, 3, 6, 1, 6, 3, 10, 2, 1, 2), Integer32().subtype(subtypeSpec=ValueRangeConstraint(1, 2147483647))).setMaxAccess("readonly")
 if mibBuilder.loadTexts: snmpEngineBoots.setStatus('current')
 if mibBuilder.loadTexts: snmpEngineBoots.setDescription('The number of times that the SNMP engine has (re-)initialized itself since snmpEngineID was last configured. ')
-snmpEngineTime = MibScalar((1, 3, 6, 1, 6, 3, 10, 2, 1, 3), SnmpEngineTime().subtype(subtypeSpec=ValueRangeConstraint(0, 2147483647))).setUnits('seconds').setMaxAccess("readonly")
+snmpEngineTime = MibScalar((1, 3, 6, 1, 6, 3, 10, 2, 1, 3), SnmpEngineTime()).setUnits('seconds').setMaxAccess("readonly")
 if mibBuilder.loadTexts: snmpEngineTime.setStatus('current')
 if mibBuilder.loadTexts: snmpEngineTime.setDescription("The number of seconds since the value of the snmpEngineBoots object last changed. When incrementing this object's value would cause it to exceed its maximum, snmpEngineBoots is incremented as if a re-initialization had occurred, and this object's value consequently reverts to zero. ")
 snmpEngineMaxMessageSize = MibScalar((1, 3, 6, 1, 6, 3, 10, 2, 1, 4), Integer32().subtype(subtypeSpec=ValueRangeConstraint(484, 2147483647))).setMaxAccess("readonly")


### PR DESCRIPTION
31-bit integers overflow after 2038-01-19

Without this patch, PySNMP cannot spawn an agent
and snimpy tests get stuck
https://github.com/vincentbernat/snimpy/issues/106

Note: I only gave it a brief test and there might be more issues 
because several snimpy tests timeout.

This patch was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).