### PR TITLE
Removed imp and changed import calls in pysnmp/smi/builder.py

### DIFF
--- a/pysnmp/smi/builder.py
+++ b/pysnmp/smi/builder.py
@@ -10,26 +10,15 @@ import struct
 import marshal
 import time
 import traceback
+import importlib.util
+import importlib.machinery
 
 try:
-    import importlib
-
-    try:
-        PY_MAGIC_NUMBER = importlib.util.MAGIC_NUMBER
-        SOURCE_SUFFIXES = importlib.machinery.SOURCE_SUFFIXES
-        BYTECODE_SUFFIXES = importlib.machinery.BYTECODE_SUFFIXES
-
-    except Exception:
-        raise ImportError()
-
-except ImportError:
-    import imp
-
-    PY_MAGIC_NUMBER = imp.get_magic()
-    SOURCE_SUFFIXES = [s[0] for s in imp.get_suffixes()
-                       if s[2] == imp.PY_SOURCE]
-    BYTECODE_SUFFIXES = [s[0] for s in imp.get_suffixes()
-                         if s[2] == imp.PY_COMPILED]
+    PY_MAGIC_NUMBER = importlib.util.MAGIC_NUMBER
+    SOURCE_SUFFIXES = importlib.machinery.SOURCE_SUFFIXES
+    BYTECODE_SUFFIXES = importlib.machinery.BYTECODE_SUFFIXES
+except Exception:
+    raise ImportError()
 
 PY_SUFFIXES = SOURCE_SUFFIXES + BYTECODE_SUFFIXES
 


### PR DESCRIPTION
Changed imports of importlib.util and importlib.machinery to explicit import (https://discuss.python.org/t/python3-11-importlib-no-longer-exposes-util/25641/10).

Removed alternative way to get PY_MAGIC_NUMBER, SOURCE_SUFFIXES and BYTECODE_SUFFIXES in pysnmp/smi/builder.py via imp module because it was removed in Python 3.12 (https://docs.python.org/3/whatsnew/3.12.html)