### PR TITLE
indices-improve-runtime

### DIFF
--- a/pysnmp/smi/indices.py
+++ b/pysnmp/smi/indices.py
@@ -79,11 +79,7 @@ class OrderedDict(dict):
 
         keys = self.__keys
 
-        if key in keys:
-            nextIdx = keys.index(key) + 1
-
-        else:
-            nextIdx = bisect(keys, key)
+        nextIdx = bisect(keys, key)
 
         if nextIdx < len(keys):
             return keys[nextIdx]


### PR DESCRIPTION
It seems that this part of the code takes a lot of processing time with no real reason:
![image](https://github.com/user-attachments/assets/88d8fa01-f230-4c4d-9e08-436fc5a0abad)
