### PR TITLE
Fix spelling error in pysnmp/carrier/base.py

### DIFF
--- a/pysnmp/carrier/base.py
+++ b/pysnmp/carrier/base.py
@@ -144,7 +144,7 @@ class AbstractTransportDispatcher:
             )
         else:
             raise error.CarrierError(
-                f'No callback for "{recvId!r}" found - loosing incoming event'
+                f'No callback for "{recvId!r}" found - losing incoming event'
             )
 
     # Dispatcher API


### PR DESCRIPTION
Changes the misspelled word "loosing" (i.e. loosening something) into "losing" (experiencing loss).