### PR TITLE
Fixed Length OID Processing Fixes

### DIFF
--- a/pysnmp/smi/mibs/INET-ADDRESS-MIB.py
+++ b/pysnmp/smi/mibs/INET-ADDRESS-MIB.py
@@ -151,7 +151,7 @@ class InetAddressIPv4(TextualConvention, OctetString):
     subtypeSpec += ConstraintsUnion(
         ValueSizeConstraint(4, 4),
     )
-    fixedLength = 4
+    fixed_length = 4
 
     if mibBuilder.loadTexts:
         description = "Represents an IPv4 network address: Octets Contents Encoding 1-4 IPv4 address network-byte order The corresponding InetAddressType value is ipv4(1). This textual convention SHOULD NOT be used directly in object definitions, as it restricts addresses to a specific format. However, if it is used, it MAY be used either on its own or in conjunction with InetAddressType, as a pair."
@@ -164,7 +164,7 @@ class InetAddressIPv6(TextualConvention, OctetString):
     subtypeSpec += ConstraintsUnion(
         ValueSizeConstraint(16, 16),
     )
-    fixedLength = 16
+    fixed_length = 16
 
     if mibBuilder.loadTexts:
         description = "Represents an IPv6 network address: Octets Contents Encoding 1-16 IPv6 address network-byte order The corresponding InetAddressType value is ipv6(2). This textual convention SHOULD NOT be used directly in object definitions, as it restricts addresses to a specific format. However, if it is used, it MAY be used either on its own or in conjunction with InetAddressType, as a pair."
@@ -177,7 +177,7 @@ class InetAddressIPv4z(TextualConvention, OctetString):
     subtypeSpec += ConstraintsUnion(
         ValueSizeConstraint(8, 8),
     )
-    fixedLength = 8
+    fixed_length = 8
 
     if mibBuilder.loadTexts:
         description = "Represents a non-global IPv4 network address, together with its zone index: Octets Contents Encoding 1-4 IPv4 address network-byte order 5-8 zone index network-byte order The corresponding InetAddressType value is ipv4z(3). The zone index (bytes 5-8) is used to disambiguate identical address values on nodes that have interfaces attached to different zones of the same scope. The zone index may contain the special value 0, which refers to the default zone for each scope. This textual convention SHOULD NOT be used directly in object definitions, as it restricts addresses to a specific format. However, if it is used, it MAY be used either on its own or in conjunction with InetAddressType, as a pair."
@@ -190,7 +190,7 @@ class InetAddressIPv6z(TextualConvention, OctetString):
     subtypeSpec += ConstraintsUnion(
         ValueSizeConstraint(20, 20),
     )
-    fixedLength = 20
+    fixed_length = 20
 
     if mibBuilder.loadTexts:
         description = "Represents a non-global IPv6 network address, together with its zone index: Octets Contents Encoding 1-16 IPv6 address network-byte order 17-20 zone index network-byte order The corresponding InetAddressType value is ipv6z(4). The zone index (bytes 17-20) is used to disambiguate identical address values on nodes that have interfaces attached to different zones of the same scope. The zone index may contain the special value 0, which refers to the default zone for each scope. This textual convention SHOULD NOT be used directly in object definitions, as it restricts addresses to a specific format. However, if it is used, it MAY be used either on its own or in conjunction with InetAddressType, as a pair."

--- a/pysnmp/smi/mibs/SNMPv2-SMI.py
+++ b/pysnmp/smi/mibs/SNMPv2-SMI.py
@@ -1228,8 +1228,8 @@ class MibTableRow(MibTree):
             # rfc1902, 7.7
             if impliedFlag:
                 return obj.clone(tuple(value)), ()
-            elif obj.isFixedLength():
-                fixed_length = obj.getFixedLength()
+            elif obj.is_fixed_length():
+                fixed_length = obj.get_fixed_length()
                 return obj.clone(tuple(value[:fixed_length])), value[fixed_length:]
             else:
                 return obj.clone(tuple(value[1 : value[0] + 1])), value[value[0] + 1 :]
@@ -1256,7 +1256,7 @@ class MibTableRow(MibTree):
         elif self.__ipaddrTagSet.isSuperTagSetOf(obj.getTagSet()):
             return obj.asNumbers()
         elif baseTag == self.__strBaseTag:
-            if impliedFlag or obj.isFixedLength():
+            if impliedFlag or obj.is_fixed_length():
                 initial = ()
             else:
                 initial = (len(obj),)

--- a/pysnmp/smi/mibs/SNMPv2-SMI.py
+++ b/pysnmp/smi/mibs/SNMPv2-SMI.py
@@ -1229,8 +1229,8 @@ class MibTableRow(MibTree):
             if impliedFlag:
                 return obj.clone(tuple(value)), ()
             elif obj.isFixedLength():
-                value = obj.getFixedLength()
-                return obj.clone(tuple(value[:value])), value[value:]
+                fixed_length = obj.getFixedLength()
+                return obj.clone(tuple(value[:fixed_length])), value[fixed_length:]
             else:
                 return obj.clone(tuple(value[1 : value[0] + 1])), value[value[0] + 1 :]
         elif baseTag == self.__oidBaseTag:

--- a/pysnmp/smi/mibs/SNMPv2-TC.py
+++ b/pysnmp/smi/mibs/SNMPv2-TC.py
@@ -519,7 +519,7 @@ class MacAddress(TextualConvention, OctetString):
     subtypeSpec += ConstraintsUnion(
         ValueSizeConstraint(6, 6),
     )
-    fixedLength = 6
+    fixed_length = 6
 
     if mibBuilder.loadTexts:
         description = "Represents an 802 MAC address represented in the `canonical' order defined by IEEE 802.1a, i.e., as if it were transmitted least significant bit first, even though 802.5 (in contrast to other 802.x protocols) requires MAC addresses to be transmitted most significant bit first."

--- a/pysnmp/smi/mibs/SNMPv2-TM.py
+++ b/pysnmp/smi/mibs/SNMPv2-TM.py
@@ -138,7 +138,7 @@ class SnmpUDPAddress(TextualConvention, OctetString):
     subtypeSpec += ConstraintsUnion(
         ValueSizeConstraint(6, 6),
     )
-    fixedLength = 6
+    fixed_length = 6
 
     if mibBuilder.loadTexts:
         description = "Represents a UDP over IPv4 address: octets contents encoding 1-4 IP-address network-byte order 5-6 UDP-port network-byte order "
@@ -202,7 +202,7 @@ class SnmpIPXAddress(TextualConvention, OctetString):
     subtypeSpec += ConstraintsUnion(
         ValueSizeConstraint(12, 12),
     )
-    fixedLength = 12
+    fixed_length = 12
 
     if mibBuilder.loadTexts:
         description = "Represents an IPX address: octets contents encoding 1-4 network-number network-byte order 5-10 physical-address network-byte order 11-12 socket-number network-byte order "

--- a/pysnmp/smi/mibs/TRANSPORT-ADDRESS-MIB.py
+++ b/pysnmp/smi/mibs/TRANSPORT-ADDRESS-MIB.py
@@ -292,7 +292,7 @@ class TransportAddressIPv4(TextualConvention, OctetString):
     subtypeSpec += ConstraintsUnion(
         ValueSizeConstraint(6, 6),
     )
-    fixedLength = 6
+    fixed_length = 6
 
     if mibBuilder.loadTexts:
         description = "Represents a transport address consisting of an IPv4 address and a port number (as used for example by UDP, TCP and SCTP): octets contents encoding 1-4 IPv4 address network-byte order 5-6 port number network-byte order This textual convention SHOULD NOT be used directly in object definitions since it restricts addresses to a specific format. However, if it is used, it MAY be used either on its own or in conjunction with TransportAddressType or TransportDomain as a pair."
@@ -331,7 +331,7 @@ class TransportAddressIPv6(TextualConvention, OctetString):
     subtypeSpec += ConstraintsUnion(
         ValueSizeConstraint(18, 18),
     )
-    fixedLength = 18
+    fixed_length = 18
 
     if mibBuilder.loadTexts:
         description = "Represents a transport address consisting of an IPv6 address and a port number (as used for example by UDP, TCP and SCTP): octets contents encoding 1-16 IPv6 address network-byte order 17-18 port number network-byte order This textual convention SHOULD NOT be used directly in object definitions since it restricts addresses to a specific format. However, if it is used, it MAY be used either on its own or in conjunction with TransportAddressType or TransportDomain as a pair."
@@ -375,7 +375,7 @@ class TransportAddressIPv4z(TextualConvention, OctetString):
     subtypeSpec += ConstraintsUnion(
         ValueSizeConstraint(10, 10),
     )
-    fixedLength = 10
+    fixed_length = 10
 
     if mibBuilder.loadTexts:
         description = "Represents a transport address consisting of an IPv4 address, a zone index and a port number (as used for example by UDP, TCP and SCTP): octets contents encoding 1-4 IPv4 address network-byte order 5-8 zone index network-byte order 9-10 port number network-byte order This textual convention SHOULD NOT be used directly in object definitions since it restricts addresses to a specific format. However, if it is used, it MAY be used either on its own or in conjunction with TransportAddressType or TransportDomain as a pair."
@@ -388,7 +388,7 @@ class TransportAddressIPv6z(TextualConvention, OctetString):
     subtypeSpec += ConstraintsUnion(
         ValueSizeConstraint(22, 22),
     )
-    fixedLength = 22
+    fixed_length = 22
 
     if mibBuilder.loadTexts:
         description = "Represents a transport address consisting of an IPv6 address, a zone index and a port number (as used for example by UDP, TCP and SCTP): octets contents encoding 1-16 IPv6 address network-byte order 17-20 zone index network-byte order 21-22 port number network-byte order This textual convention SHOULD NOT be used directly in object definitions since it restricts addresses to a specific format. However, if it is used, it MAY be used either on its own or in conjunction with TransportAddressType or TransportDomain as a pair."

--- a/tests/agent_context.py
+++ b/tests/agent_context.py
@@ -87,12 +87,14 @@ async def start_agent(
         (
             DisplayString,
             PhysAddress,
+            MacAddress,
             DateAndTime,
             TextualConvention,
         ) = mibBuilder.importSymbols(
             "SNMPv2-TC",
             "DisplayString",
             "PhysAddress",
+            "MacAddress",
             "DateAndTime",
             "TextualConvention",
         )
@@ -126,6 +128,9 @@ async def start_agent(
 
         # Initialize the PhysAddress object with a sample MAC address (e.g., 00:11:22:33:44:55)
         initial_phys_address = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55]
+
+        # Initialize the MacAddress object with a sample MAC address (e.g., 00:11:22:33:44:55)
+        initial_mac_address = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55]
 
         mibBuilder.export_symbols(
             "__MY_MIB",
@@ -161,6 +166,12 @@ async def start_agent(
                 "read-write"
             ),
             MibScalarInstance((1, 3, 6, 1, 4, 1, 60069, 9, 8), (0,), v2c.Unsigned32(5)),
+            MibScalar((1, 3, 6, 1, 4, 1, 60069, 9, 9), MacAddress()).setMaxAccess(
+                "read-write"
+            ),
+            MibScalarInstance(
+                (1, 3, 6, 1, 4, 1, 60069, 9, 9), (0,), MacAddress(initial_mac_address)
+            ),
         )
 
         # --- end of Managed Object Instance initialization ----

--- a/tests/hlapi/v1arch/asyncio/manager/cmdgen/test_v1arch_v1_set.py
+++ b/tests/hlapi/v1arch/asyncio/manager/cmdgen/test_v1arch_v1_set.py
@@ -1,10 +1,11 @@
 import pytest
 from pysnmp.entity.engine import SnmpEngine
-from pysnmp.hlapi.v1arch.asyncio.cmdgen import set_cmd, walk_cmd
+from pysnmp.hlapi.v1arch.asyncio.cmdgen import get_cmd, set_cmd, walk_cmd
 from pysnmp.hlapi.v1arch.asyncio.dispatch import SnmpDispatcher
 from pysnmp.hlapi.v1arch.asyncio.transport import UdpTransportTarget
 from pysnmp.hlapi.v1arch.asyncio.auth import CommunityData
 from pysnmp.proto.rfc1902 import Integer, OctetString
+from pysnmp.smi import builder, compiler, view
 from pysnmp.smi.rfc1902 import ObjectIdentity, ObjectType
 from tests.agent_context import AGENT_PORT, AgentContextManager
 
@@ -31,6 +32,55 @@ async def test_v1_set():
         assert isinstance(varBinds[0][1], OctetString)
 
         snmpDispatcher.transport_dispatcher.close_dispatcher()
+
+
+@pytest.mark.asyncio
+async def test_v1_set_mac_address():
+    async with AgentContextManager(enable_custom_objects=True):
+        snmpDispatcher = SnmpDispatcher()
+        # Step 1: Set up MIB builder and add custom MIB directory
+        mibBuilder = builder.MibBuilder()
+        compiler.addMibCompiler(mibBuilder)
+        mibViewController = view.MibViewController(mibBuilder)
+
+        # Load the custom MIB
+        mibBuilder.loadModules("LEXTUDIO-TEST-MIB")
+        snmpDispatcher.cache["mibViewController"] = mibViewController
+
+        errorIndication, errorStatus, errorIndex, varBinds = await get_cmd(
+            snmpDispatcher,
+            CommunityData("public", mpModel=0),
+            await UdpTransportTarget.create(
+                ("localhost", AGENT_PORT), timeout=1, retries=0
+            ),
+            ObjectType(
+                ObjectIdentity("LEXTUDIO-TEST-MIB", "testMacAddress", 0)
+            ),  # "1.3.6.1.4.1.60069.9.9.0"
+        )
+        assert errorIndication is None
+        assert errorIndication is None
+        assert errorStatus == 0
+        assert errorIndex == 0
+        assert len(varBinds) == 1
+        assert varBinds[0][0].prettyPrint() == "LEXTUDIO-TEST-MIB::testMacAddress.0"
+        assert (
+            varBinds[0][1].prettyPrint() == "00:11:22:33:44:55"
+        )  # IMPORTANT: OCTET STRING Size constraint 6..6
+
+        errorIndication, errorStatus, errorIndex, varBinds = await set_cmd(
+            snmpDispatcher,
+            CommunityData("public", mpModel=0),
+            await UdpTransportTarget.create(("localhost", AGENT_PORT)),
+            ObjectType(
+                ObjectIdentity("LEXTUDIO-TEST-MIB", "testMacAddress", 0),
+                OctetString("00:11:22:33:44:55:66"),  # GitHub issue #141
+            ),
+        )
+
+        assert errorIndication is None
+        assert errorStatus == 3  # bad value
+        assert errorIndex == 1
+        assert len(varBinds) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/smi/manager/test_configure-mib-viewer-and-resolve-pdu-varbinds.py
+++ b/tests/smi/manager/test_configure-mib-viewer-and-resolve-pdu-varbinds.py
@@ -106,7 +106,9 @@ def test_syntax_integer():
 
     # Load MIB modules
     compiler.addMibCompiler(mib_builder)
-    mib_builder.loadModules("LEXTUDIO-TEST-MIB")
+    mib_builder.loadModules(
+        "LEXTUDIO-TEST-MIB"
+    )  # IMPORTANT: compile LEXTUDIO-TEST-MIB.mib in advance.
 
     # Get MIB object
     (mib_object,) = mib_builder.import_symbols("LEXTUDIO-TEST-MIB", "testScaledInteger")
@@ -132,3 +134,21 @@ def test_syntax_unsigned():
     # Print MIB object syntax
     assert (1, 3, 6, 1, 4, 1, 60069, 9, 8) == mib_object.getName()
     assert "ScaledUnsigned" == mib_object.syntax.__class__.__name__
+
+
+def test_syntax_fixed_length_octet_string():
+    # Create MIB builder
+    mib_builder = builder.MibBuilder()
+
+    # Load MIB modules
+    compiler.addMibCompiler(mib_builder)
+    mib_builder.loadModules(
+        "LEXTUDIO-TEST-MIB"
+    )  # IMPORTANT: compile LEXTUDIO-TEST-MIB.mib in advance.
+
+    # Get MIB object
+    (mib_object,) = mib_builder.import_symbols("LEXTUDIO-TEST-MIB", "testMacAddress")
+
+    # Print MIB object syntax
+    assert (1, 3, 6, 1, 4, 1, 60069, 9, 9) == mib_object.getName()
+    assert "MacAddress" == mib_object.syntax.__class__.__name__


### PR DESCRIPTION
Sorry for the long wait on this, I have been super busy and didn't manage to get around to this.

For context: This fixes the closed issue https://github.com/lextudio/pysnmp/issues/141 that is still present in the main branch after some initial testing.
 
The following pull request restores the Fixed Length OID processing functionality that began to cause crashes for fixed length OID strings after PEP 8 changes were applied. Additionally, this updates the SNMPv2-SMI.py file to use the newer PEP 8 compliant function names.