### PR TITLE
Fix documentation error and improve v1arch hlapi notes

### DIFF
--- a/pysnmp/hlapi/v1arch/asyncio/cmdgen.py
+++ b/pysnmp/hlapi/v1arch/asyncio/cmdgen.py
@@ -385,7 +385,6 @@ async def next_cmd(
     ...         SnmpDispatcher(),
     ...         CommunityData('public'),
     ...         await UdpTransportTarget.create(('demo.pysnmp.com', 161)),
-    ...         ContextData(),
     ...         ObjectType(ObjectIdentity('SNMPv2-MIB', 'system'))
     ...     )
     ...     print(errorIndication, errorStatus, errorIndex, varBinds)
@@ -478,7 +477,7 @@ async def bulk_cmd(
         associated state information.
 
     authData: :py:class:`~pysnmp.hlapi.v1arch.asyncio.CommunityData`
-        Class instance representing SNMPv1/v2c credentials.
+        Class instance representing SNMPv2c credentials. (SNMPv1 / mpModel=0 is not allowed)
 
     transportTarget: :py:class:`~pysnmp.hlapi.v1arch.asyncio.UdpTransportTarget` or
         :py:class:`~pysnmp.hlapi.v1arch.asyncio.Udp6TransportTarget` Class instance representing
@@ -838,7 +837,7 @@ async def bulk_walk_cmd(
         Class instance representing SNMP engine.
 
     authData : :py:class:`~pysnmp.hlapi.v1arch.asyncio.CommunityData`
-        Class instance representing SNMP credentials.
+        Class instance representing SNMPv2c credentials. (SNMPv1 / mpModel=0 is not allowed)
 
     transportTarget : :py:class:`~pysnmp.hlapi.v1arch.asyncio.UdpTransportTarget` or :py:class:`~pysnmp.hlapi.v1arch.asyncio.Udp6TransportTarget`
         Class instance representing transport type along with SNMP peer address.


### PR DESCRIPTION
__Fixing documentation error and improving v1arch hlapi notes__

- remove `ContextData()` which is not valid with `SnmpDispatcher()`
- remind that `bulk_cmd()` and `bulk_walk_cmd()` do not allow SNMPv1 (`CommunityData(community, mpModel=0)`)