### PR TITLE
Add synchronous adapters for asyncio HLAPI

### DIFF
--- a/pysnmp/hlapi/v1arch/asyncio/sync_adapters.py
+++ b/pysnmp/hlapi/v1arch/asyncio/sync_adapters.py
@@ -1,0 +1,63 @@
+import asyncio
+import functools
+from pysnmp.hlapi.v1arch.asyncio import *
+
+def ensure_loop():
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    return loop
+
+def create_transport(host: str, port: int, timeout: float = 1.0):
+    """
+    Await the async factory to build UdpTransportTarget once,
+    using our shared loop.
+    """
+    loop = ensure_loop()
+    coro = UdpTransportTarget.create((host, port), timeout=timeout)
+    return loop.run_until_complete(coro)
+
+def _sync_coro(coro):
+    """
+    Run the given coroutine to completion on the shared loop,
+    scheduling if needed.
+    """
+    loop = ensure_loop()
+    if loop.is_running():
+        fut = asyncio.ensure_future(coro)
+        return loop.run_until_complete(fut)
+    return loop.run_until_complete(coro)
+
+def _sync_agen(agen):
+    """
+    Consume an async-generator into a list synchronously.
+    """
+    async def _collector():
+        items = []
+        async for item in agen:
+            items.append(item)
+        return items
+
+    return _sync_coro(_collector())
+
+def make_sync(fn):
+    """Turn any pysnmp async‐HLAPI fn into a sync wrapper."""
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        return _sync_coro(fn(*args, **kwargs))
+    return wrapper
+
+get_cmd_sync = make_sync(get_cmd)
+next_cmd_sync = make_sync(next_cmd)
+set_cmd_sync = make_sync(set_cmd)
+bulk_cmd_sync = make_sync(bulk_cmd)
+
+def walk_cmd_sync(*args, **kwargs):
+    """Sync wrapper for walk_cmd (async generator)."""
+    return _sync_agen(walk_cmd(*args, **kwargs))
+
+def bulk_walk_cmd_sync(*args, **kwargs):
+    """Sync wrapper for bulk_walk_cmd (async generator)."""
+    return _sync_agen(bulk_walk_cmd(*args, **kwargs))


### PR DESCRIPTION
__Add synchronous adapters for asyncio HLAPI__

This PR introduces `sync_adapters.py` under `pysnmp/hlapi/v1arch/asyncio/`. It provides:

- `ensure_loop()` — reuses or creates a single event loop.
- `create_transport()` — pre-awaits `UdpTransportTarget.create()` once.
- `_sync_coro()` & `_sync_agen()` — run async coroutines or consume async generators to completion.
- `make_sync()` helper to wrap all six HLAPI commands (`get_cmd`, `next_cmd`, `set_cmd`, `bulk_cmd`, `walk_cmd`, `bulk_walk_cmd`) in synchronous equivalents:
   * `get_cmd_sync`
   * `next_cmd_sync`
   * `set_cmd_sync`
   * `bulk_cmd_sync`
   * `walk_cmd_sync`
   * `bulk_walk_cmd_sync`

With these adapters, users can call the familiar HLAPI functions in a purely synchronous style (e.g. in scripts or blocking contexts) without having to manage asyncio directly. This restores the “sync” experience in PySNMP v7 for applications that do not use asyncio.

By caching a single event loop via ensure_loop(), we eliminate the overhead of creating/closing a loop on every SNMP request. This yields up significant performance improvement in tight loops.

Example usage:

```python
import asyncio
import platform

from pysnmp.hlapi.v1arch.asyncio import *

from pysnmp.hlapi.v1arch.asyncio.sync_adapters import (
    get_cmd_sync, next_cmd_sync, set_cmd_sync, bulk_cmd_sync,
    walk_cmd_sync, bulk_walk_cmd_sync, create_transport
)

if platform.system()=='Windows':
    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

community = 'public'
dispatcher = SnmpDispatcher()
authData = CommunityData(community, mpModel=0)

print("\n--> get_cmd_sync")
errorIndication, errorStatus, errorIndex, varBinds = get_cmd_sync(
    dispatcher,
    authData,
    create_transport('demo.pysnmp.com', 161, timeout=2),
    ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr', 0))
)
print(errorIndication, errorStatus, errorIndex)
for name, val in varBinds:
    print(name.prettyPrint(), '=', val.prettyPrint())

print("\n--> set_cmd_sync")
errorIndication, errorStatus, errorIndex, varBinds = set_cmd_sync(
    dispatcher,
    authData,
    create_transport('demo.pysnmp.com', 161, timeout=2),
    ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr', 0), 'Linux i386')
)
print(errorIndication, errorStatus, errorIndex)
for name, val in varBinds:
    print(name.prettyPrint(), '=', val.prettyPrint())

print("\n--> next_cmd_sync")
errorIndication, errorStatus, errorIndex, varBinds = next_cmd_sync(
    dispatcher,
    authData,
    create_transport('demo.pysnmp.com', 161, timeout=2),
    ObjectType(ObjectIdentity('SNMPv2-MIB', 'system'))
)
print(errorIndication, errorStatus, errorIndex)
for name, val in varBinds:
    print(name.prettyPrint(), '=', val.prettyPrint())

print("\n--> bulk_cmd_sync")
errorIndication, errorStatus, errorIndex, varBinds = bulk_cmd_sync(
    dispatcher,
    CommunityData('public'),
    create_transport('demo.pysnmp.com', 161, timeout=2),
    0, 2,
    ObjectType(ObjectIdentity('SNMPv2-MIB', 'system'))
)
print(errorIndication, errorStatus, errorIndex)
for name, val in varBinds:
    print(name.prettyPrint(), '=', val.prettyPrint())

print("\n--> walk_cmd_sync")
objects = walk_cmd_sync(
    dispatcher,
    authData,
    create_transport('demo.pysnmp.com', 161, timeout=2),
    ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr'))
)
g = [item for item in objects]
for i in g:
    print(str(i[3][0][0]))

print("\n--> bulk_walk_cmd_sync")
objects = bulk_walk_cmd_sync(
    dispatcher,
    CommunityData('public'),
    create_transport('demo.pysnmp.com', 161, timeout=2),
    0, 25,
    ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr')))
g = [item for item in objects]
for i in g:
    print(str(i[3][0][0]))
```

Drawbacks:

- These adapters block the calling thread until the SNMP operation completes.
- If the host app already drives an asyncio loop, calling these wrappers on that same loop can error or deadlock unless isolated (e.g. in a separate thread).
- The only way those calls give up on a slow or unresponsive SNMP peer is via the low-level socket own timeout; there’s no exposed mechanism to cancel the underlying asyncio task.