### PR TITLE
fix AsyncioDispatcher creating event loop even if provided via `kwargs`

### DIFF
--- a/pysnmp/carrier/asyncio/dispatch.py
+++ b/pysnmp/carrier/asyncio/dispatch.py
@@ -57,7 +57,7 @@ class AsyncioDispatcher(AbstractTransportDispatcher):
         if "timeout" in kwargs:
             self.set_timer_resolution(kwargs["timeout"])
         self.loopingcall = None
-        self.loop = kwargs.pop("loop", asyncio.get_event_loop())
+        self.loop = kwargs.pop("loop", None) or asyncio.get_event_loop()
 
     async def handle_timeout(self):
         """Handle timeout event with proper error handling."""


### PR DESCRIPTION
`<dict>.pop(<key>, <default>)` acts non-lazily and will evaluate `<default>` unconditionally.

This makes
```
self.loop = kwargs.pop('loop', asyncio.get_event_loop())
```
create an event loop even if `loop` is present in `kwargs` leading to undesired behavior, specially in multithreaded scenarios where you don't have an automatically created default event loop.

This change makes `kwargs.pop()` default to `None` instead and provides the default value via `or` (which is evaluated lazily).