### PR TITLE
feat: introduced multi_bulk_walk_cmd

### DIFF
--- a/pysnmp/hlapi/v1arch/asyncio/cmdgen.py
+++ b/pysnmp/hlapi/v1arch/asyncio/cmdgen.py
@@ -25,6 +25,7 @@ __all__ = [
     "bulk_cmd",
     "walk_cmd",
     "bulk_walk_cmd",
+    "multi_bulk_walk_cmd",
     "is_end_of_mib",
 ]
 
@@ -1160,22 +1161,18 @@ async def multi_bulk_walk_cmd(
     totalRows = 0
     totalCalls = 0
 
-    # Continue until all varbinds are exhausted
     while True:
 
+        # Used to keep valid varbinds to yield.
         valid_results = []
         if varBinds:
-            # Adjust maxRepetitions if approaching maxRows limit
             if maxRows and totalRows < maxRows:
-                adjusted_max_reps = min(maxRepetitions, maxRows - totalRows)
-            else:
-                adjusted_max_reps = maxRepetitions
+                maxRepetitions = min(maxRepetitions, maxRows - totalRows)
 
             # Build request varbinds from currently active (non-completed) varbinds
             active_indices = [i for i in range(num_varbinds) if not completed[i]]
 
             if not active_indices:
-                # All varbinds have completed their walk
                 return
 
             # Create request varbinds using last known OIDs for active varbinds
@@ -1196,7 +1193,7 @@ async def multi_bulk_walk_cmd(
                 authData,
                 transportTarget,
                 nonRepeaters,
-                adjusted_max_reps,
+                maxRepetitions,
                 *request_varbinds,
                 **dict(lookupMib=options.get("lookupMib", True)),
             )
@@ -1233,63 +1230,32 @@ async def multi_bulk_walk_cmd(
                 )
                 return
             else:
-                # Successful response - process the varBindTable
                 if not varBindTable:
                     return
 
-                # Group responses by source varbind
-                # bulk_cmd returns: [vb0_r0, vb1_r0, ..., vbN_r0, vb0_r1, vb1_r1, ...]
-                # Which regroup to: [[vb0_r0, vb0_r1, ...], [vb1_r0, vb1_r1, ...]]
                 num_active = len(active_indices)
-                responses_per_varbind = [[] for _ in range(num_active)]
+                stopFlag = True
 
                 for idx, response_vb in enumerate(varBindTable):
                     active_vb_idx = idx % num_active
-                    responses_per_varbind[active_vb_idx].append(response_vb)
+                    original_idx = active_indices[active_vb_idx]
+                    name, val = response_vb
 
-                # Collect all valid responses from this bulk_cmd call
-                stopFlag = True
+                    # Check if beyond initial scope (when lexicographicMode=False)
+                    foundEnding = isinstance(val, (Null, EndOfMibView))
+                    foundBeyond = not lexicographicMode and not initialVars[
+                        original_idx
+                    ].isPrefixOf(name)
+                    is_end_of_mib_val = val is endOfMibView
 
-                for active_idx, original_idx in enumerate(active_indices):
-                    responses = responses_per_varbind[active_idx]
-
-                    if not responses:
+                    if foundEnding or foundBeyond or is_end_of_mib_val:
                         completed[original_idx] = True
                         continue
 
-                    # Track last valid OID for this varbind
-                    last_valid_oid = None
-                    varbind_still_active = False
-
-                    # Process all responses for this varbind
-                    for response_vb in responses:
-                        name, val = response_vb
-                        foundEnding = isinstance(val, Null) or isinstance(
-                            val, EndOfMibView
-                        )
-
-                        # Check if beyond initial scope (when lexicographicMode=False)
-                        foundBeyond = not lexicographicMode and not initialVars[
-                            original_idx
-                        ].isPrefixOf(name)
-
-                        # Check for endOfMibView sentinel
-                        is_end_of_mib_val = val is endOfMibView
-
-                        if foundEnding or foundBeyond or is_end_of_mib_val:
-                            # This response is beyond scope or end - mark varbind as completed and stop processing
-                            completed[original_idx] = True
-                            break
-
-                        # Valid response - add to results
-                        valid_results.append(response_vb)
-                        last_valid_oid = name
-                        varbind_still_active = True
-                        stopFlag = False
-
-                    # Update last OID for next iteration if we have valid responses
-                    if last_valid_oid is not None and varbind_still_active:
-                        last_oids[original_idx] = last_valid_oid
+                    # Valid response - add to results
+                    valid_results.append(response_vb)
+                    last_oids[original_idx] = name
+                    stopFlag = False
 
                 totalRows += len(valid_results)
                 totalCalls += 1
@@ -1310,8 +1276,21 @@ async def multi_bulk_walk_cmd(
                 if not valid_results:
                     return
 
+                if maxRows and totalRows > maxRows:
+                    excess = totalRows - maxRows
+                    keep_count = len(valid_results) - excess
+                    
+                    if keep_count > 0:
+                        valid_results = valid_results[:keep_count]
+                        totalRows = maxRows
+                    else:
+                        # This entire batch exceeds the limit
+                        return
+
         else:
-            errorIndication = errorStatus = errorIndex = None
+            errorIndication = None
+            errorStatus = None
+            errorIndex = None
             varBinds = ()
 
         # Yield all collected valid varBinds for this batch

--- a/pysnmp/hlapi/v1arch/asyncio/cmdgen.py
+++ b/pysnmp/hlapi/v1arch/asyncio/cmdgen.py
@@ -15,7 +15,7 @@ from pysnmp.hlapi.v1arch.asyncio.dispatch import SnmpDispatcher
 from pysnmp.proto import api, errind
 from pysnmp.proto.rfc1902 import Integer32, Null
 from pysnmp.proto.rfc1905 import EndOfMibView, endOfMibView
-from pysnmp.smi.rfc1902 import ObjectType
+from pysnmp.smi.rfc1902 import ObjectType, ObjectIdentity
 
 
 __all__ = [
@@ -1029,6 +1029,319 @@ async def bulk_walk_cmd(
             return
 
         if maxCalls and totalCalls >= maxCalls:
+            return
+
+
+async def multi_bulk_walk_cmd(
+    dispatcher: SnmpDispatcher,
+    authData: CommunityData,
+    transportTarget: AbstractTransportTarget,
+    nonRepeaters: int,
+    maxRepetitions: int,
+    *varBinds: ObjectType,
+    **options,
+) -> AsyncGenerator[
+    "tuple[errind.ErrorIndication | None, Integer32 | str | int | None, Integer32 | int | None, tuple[ObjectType, ...]]",
+    None,
+]:
+    r"""Creates a generator to perform SNMP GETBULK queries with multiple OID trees.
+
+    This function extends the bulk_walk_cmd functionality to support walking multiple
+    OID trees simultaneously while respecting lexicographic mode for each varbind
+    independently. Each varbind is tracked separately and will stop iteration when
+    it reaches its natural boundary or goes out of scope.
+
+    On each iteration, new SNMP GETBULK request is sent (:RFC:`1905#section-4.2.3`).
+    The iterator blocks waiting for response to arrive or error to occur. Unlike
+    bulk_walk_cmd which only handles a single varbind, this function can handle
+    multiple varbinds in parallel, applying lexicographic mode filtering to each.
+
+    Parameters
+    ----------
+    snmpEngine : :py:class:`~pysnmp.hlapi.v1arch.asyncio.SnmpDispatcher`
+        Class instance representing SNMP engine.
+
+    authData : :py:class:`~pysnmp.hlapi.v1arch.asyncio.CommunityData`
+        Class instance representing SNMPv2c credentials. (SNMPv1 / mpModel=0 is not allowed)
+
+    transportTarget : :py:class:`~pysnmp.hlapi.v1arch.asyncio.UdpTransportTarget` or :py:class:`~pysnmp.hlapi.v1arch.asyncio.Udp6TransportTarget`
+        Class instance representing transport type along with SNMP peer address.
+
+    nonRepeaters : int
+        One MIB variable is requested in response for the first
+        `nonRepeaters` MIB variables in request.
+
+    maxRepetitions : int
+        `maxRepetitions` MIB variables are requested in response for each
+        of the remaining MIB variables in the request (e.g. excluding
+        `nonRepeaters`). Remote SNMP engine may choose lesser value than
+        requested.
+
+    *varBinds : :py:class:`~pysnmp.smi.rfc1902.ObjectType`
+        One or more class instances representing MIB variables to place
+        into SNMP request. Each varbind represents a separate OID tree to walk.
+
+    Other Parameters
+    ----------------
+    \*\*options :
+        Request options:
+
+            * `lookupMib` - load MIB and resolve response MIB variables at
+              the cost of slightly reduced performance. Default is `True`.
+            * `lexicographicMode` - walk SNMP agent's MIB till the end (if `True`),
+              otherwise (if `False`) stop iteration when all response MIB
+              variables leave the scope of initial MIB variables in
+              `varBinds`. Default is `True`.
+            * `ignoreNonIncreasingOid` - continue iteration even if response
+              MIB variables (OIDs) are not greater then request MIB variables.
+              Be aware that setting it to `True` may cause infinite loop between
+              SNMP management and agent applications. Default is `False`.
+            * `maxRows` - stop iteration once this generator instance processed
+              `maxRows` of SNMP conceptual table. Default is `0` (no limit).
+            * `maxCalls` - stop iteration once this generator instance processed
+              `maxCalls` responses. Default is 0 (no limit).
+
+    Yields
+    ------
+    errorIndication : str
+        True value indicates SNMP engine error.
+    errorStatus : str
+        True value indicates SNMP PDU error.
+    errorIndex : int
+        Non-zero value refers to varBinds[errorIndex-1]
+    varBinds : tuple
+        A sequence of :py:class:`~pysnmp.smi.rfc1902.ObjectType` class
+        instances representing MIB variables returned in SNMP response.
+        Contains all valid OIDs from the current GETBULK response batch.
+
+    Raises
+    ------
+    PySnmpError
+        Or its derivative indicating that an error occurred while
+        performing SNMP operation.
+
+    Notes
+    -----
+    Key Behavioral Differences from bulk_walk_cmd:
+
+     - Supports multiple varbinds simultaneously: the generator can walk multiple
+      OID subtrees in parallel within a single SNMP session.
+     - Each varbind is independently tracked: completion, last OID, and
+      lexicographic boundaries are maintained per varbind.
+     - lexicographicMode is applied per-varbind: a varbind stops only when its
+      own scope is exhausted if lexicographicMode=False. Other varbinds continue.
+     - Can optionally ignore non-increasing OIDs: if ignoreNonIncreasingOid=True,
+      the generator continues even when the agent returns OIDs that are not
+      greater than previous ones.
+     - Returns all valid responses from each GETBULK call in a single yield: all
+      active varbinds' results are grouped together in the same batch.
+     - Respects maxRows and maxCalls limits across all varbinds combined.
+     - Handles timeouts gracefully: the generator continues unless the error
+      is non-recoverable.
+
+    """
+    lexicographicMode = options.get("lexicographicMode", True)
+    ignoreNonIncreasingOid = options.get("ignoreNonIncreasingOid", False)
+    maxRows = options.get("maxRows", 0)
+    maxCalls = options.get("maxCalls", 0)
+
+    initialVars = [x[0] for x in VB_PROCESSOR.make_varbinds(dispatcher.cache, varBinds)]
+    num_varbinds = len(initialVars)
+
+    # Track state for each varbind independently
+    completed = [False] * num_varbinds
+
+    # Track last seen OID per varbind (used for next bulk_cmd request)
+    last_oids = [
+        vb[0] if isinstance(vb[0], ObjectIdentity) else ObjectIdentity(vb[0])
+        for vb in varBinds
+    ]
+
+    totalRows = 0
+    totalCalls = 0
+
+    # Continue until all varbinds are exhausted
+    while True:
+
+        valid_results = []
+        if varBinds:
+            # Adjust maxRepetitions if approaching maxRows limit
+            if maxRows and totalRows < maxRows:
+                adjusted_max_reps = min(maxRepetitions, maxRows - totalRows)
+            else:
+                adjusted_max_reps = maxRepetitions
+
+            # Build request varbinds from currently active (non-completed) varbinds
+            active_indices = [i for i in range(num_varbinds) if not completed[i]]
+
+            if not active_indices:
+                # All varbinds have completed their walk
+                return
+
+            # Create request varbinds using last known OIDs for active varbinds
+            request_varbinds = [
+                ObjectType(
+                    (
+                        last_oids[i]
+                        if isinstance(last_oids[i], ObjectIdentity)
+                        else ObjectIdentity(last_oids[i])
+                    ),
+                    Null(""),
+                )
+                for i in active_indices
+            ]
+
+            errorIndication, errorStatus, errorIndex, varBindTable = await bulk_cmd(
+                dispatcher,
+                authData,
+                transportTarget,
+                nonRepeaters,
+                adjusted_max_reps,
+                *request_varbinds,
+                **dict(lookupMib=options.get("lookupMib", True)),
+            )
+
+            if (
+                ignoreNonIncreasingOid
+                and errorIndication
+                and isinstance(errorIndication, errind.OidNotIncreasing)
+            ):
+                errorIndication = None
+
+            if errorIndication:
+                yield (
+                    errorIndication,
+                    errorStatus,
+                    errorIndex,
+                    varBindTable and tuple(varBindTable) or (),
+                )
+                if errorIndication != errind.requestTimedOut:
+                    return
+            elif errorStatus:
+                # SNMP PDU errors from agent
+                if errorStatus == 2:
+                    # Hide SNMPv1 noSuchName error which leaks in here
+                    # from SNMPv1 Agent through internal pysnmp proxy
+                    errorStatus = 0
+                    errorIndex = 0
+
+                yield (
+                    errorIndication,
+                    errorStatus,
+                    errorIndex,
+                    tuple(ObjectType(last_oids[i], Null("")) for i in active_indices),
+                )
+                return
+            else:
+                # Successful response - process the varBindTable
+                if not varBindTable:
+                    return
+
+                # Group responses by source varbind
+                # bulk_cmd returns: [vb0_r0, vb1_r0, ..., vbN_r0, vb0_r1, vb1_r1, ...]
+                # Which regroup to: [[vb0_r0, vb0_r1, ...], [vb1_r0, vb1_r1, ...]]
+                num_active = len(active_indices)
+                responses_per_varbind = [[] for _ in range(num_active)]
+
+                for idx, response_vb in enumerate(varBindTable):
+                    active_vb_idx = idx % num_active
+                    responses_per_varbind[active_vb_idx].append(response_vb)
+
+                # Collect all valid responses from this bulk_cmd call
+                stopFlag = True
+
+                for active_idx, original_idx in enumerate(active_indices):
+                    responses = responses_per_varbind[active_idx]
+
+                    if not responses:
+                        completed[original_idx] = True
+                        continue
+
+                    # Track last valid OID for this varbind
+                    last_valid_oid = None
+                    varbind_still_active = False
+
+                    # Process all responses for this varbind
+                    for response_vb in responses:
+                        name, val = response_vb
+                        foundEnding = isinstance(val, Null) or isinstance(
+                            val, EndOfMibView
+                        )
+
+                        # Check if beyond initial scope (when lexicographicMode=False)
+                        foundBeyond = not lexicographicMode and not initialVars[
+                            original_idx
+                        ].isPrefixOf(name)
+
+                        # Check for endOfMibView sentinel
+                        is_end_of_mib_val = val is endOfMibView
+
+                        if foundEnding or foundBeyond or is_end_of_mib_val:
+                            # This response is beyond scope or end - mark varbind as completed and stop processing
+                            completed[original_idx] = True
+                            break
+
+                        # Valid response - add to results
+                        valid_results.append(response_vb)
+                        last_valid_oid = name
+                        varbind_still_active = True
+                        stopFlag = False
+
+                    # Update last OID for next iteration if we have valid responses
+                    if last_valid_oid is not None and varbind_still_active:
+                        last_oids[original_idx] = last_valid_oid
+
+                totalRows += len(valid_results)
+                totalCalls += 1
+
+                # If stopFlag is True, all varbinds have completed
+                if stopFlag:
+                    # Check if we have any final results to yield
+                    if valid_results:
+                        yield (
+                            errorIndication,
+                            errorStatus,
+                            errorIndex,
+                            tuple(valid_results),
+                        )
+                    return
+
+                # If no valid results, stop walking
+                if not valid_results:
+                    return
+
+        else:
+            errorIndication = errorStatus = errorIndex = None
+            varBinds = ()
+
+        # Yield all collected valid varBinds for this batch
+        initialVarBinds: "tuple[ObjectType, ...]|None" = (
+            yield errorIndication,
+            errorStatus,
+            errorIndex,
+            tuple(valid_results),
+        )
+
+        if initialVarBinds:
+            num_new = len(initialVarBinds)
+
+            new_initial_vars = [
+                x[0]
+                for x in VB_PROCESSOR.make_varbinds(dispatcher.cache, initialVarBinds)
+            ]
+
+            initialVars = new_initial_vars
+            num_varbinds = num_new
+            completed = [False] * num_varbinds
+            last_oids = [vb[0] for vb in initialVarBinds]
+
+        if maxRows and totalRows >= maxRows:
+            return
+
+        if maxCalls and totalCalls >= maxCalls:
+            return
+
+        if all(completed):
             return
 
 

--- a/pysnmp/hlapi/v3arch/asyncio/cmdgen.py
+++ b/pysnmp/hlapi/v3arch/asyncio/cmdgen.py
@@ -47,7 +47,7 @@ from pysnmp.hlapi.v3arch.asyncio.transport import AbstractTransportTarget
 from pysnmp.proto import errind
 from pysnmp.proto.rfc1902 import Integer32, Null
 from pysnmp.proto.rfc1905 import EndOfMibView, endOfMibView
-from pysnmp.smi.rfc1902 import ObjectType
+from pysnmp.smi.rfc1902 import ObjectType, ObjectIdentity
 
 
 __all__ = [
@@ -1040,6 +1040,340 @@ async def bulk_walk_cmd(
             return
 
         if maxCalls and totalCalls >= maxCalls:
+            return
+
+
+async def multi_bulk_walk_cmd(
+    snmpEngine: SnmpEngine,
+    authData: "CommunityData | UsmUserData",
+    transportTarget: AbstractTransportTarget,
+    contextData: ContextData,
+    nonRepeaters: int,
+    maxRepetitions: int,
+    *varBinds: ObjectType,
+    **options,
+) -> AsyncGenerator[
+    "tuple[errind.ErrorIndication | None, Integer32 | str | int | None, Integer32 | int | None, tuple[ObjectType, ...]]",
+    None,
+]:
+    r"""Creates a generator to perform SNMP GETBULK queries with multiple OID trees.
+
+    This function extends the bulk_walk_cmd functionality to support walking multiple
+    OID trees simultaneously while respecting lexicographic mode for each varbind
+    independently. Each varbind is tracked separately and will stop iteration when
+    it reaches its natural boundary or goes out of scope.
+
+    On each iteration, new SNMP GETBULK request is sent (:RFC:`1905#section-4.2.3`).
+    The iterator blocks waiting for response to arrive or error to occur. Unlike
+    bulk_walk_cmd which only handles a single varbind, this function can handle
+    multiple varbinds in parallel, applying lexicographic mode filtering to each.
+
+    Parameters
+    ----------
+    snmpEngine : :py:class:`~pysnmp.hlapi.v3arch.asyncio.SnmpEngine`
+        Class instance representing SNMP engine.
+
+    authData : :py:class:`~pysnmp.hlapi.v3arch.asyncio.CommunityData` or :py:class:`~pysnmp.hlapi.v3arch.asyncio.UsmUserData`
+        Class instance representing SNMP credentials.
+
+    transportTarget : :py:class:`~pysnmp.hlapi.v3arch.asyncio.UdpTransportTarget` or :py:class:`~pysnmp.hlapi.v3arch.asyncio.Udp6TransportTarget`
+        Class instance representing transport type along with SNMP peer address.
+
+    contextData : :py:class:`~pysnmp.hlapi.v3arch.asyncio.ContextData`
+        Class instance representing SNMP ContextEngineId and ContextName values.
+
+    nonRepeaters : int
+        One MIB variable is requested in response for the first
+        `nonRepeaters` MIB variables in request.
+
+    maxRepetitions : int
+        `maxRepetitions` MIB variables are requested in response for each
+        of the remaining MIB variables in the request (e.g. excluding
+        `nonRepeaters`). Remote SNMP engine may choose lesser value than
+        requested.
+
+    *varBinds : :py:class:`~pysnmp.smi.rfc1902.ObjectType`
+        One or more class instances representing MIB variables to place
+        into SNMP request. Each varbind represents a separate OID tree to walk.
+
+    Other Parameters
+    ----------------
+    \*\*options :
+        Request options:
+
+            * `lookupMib` - load MIB and resolve response MIB variables at
+              the cost of slightly reduced performance. Default is `True`.
+            * `lexicographicMode` - walk SNMP agent's MIB till the end (if `True`),
+              otherwise (if `False`) stop iteration when all response MIB
+              variables leave the scope of initial MIB variables in
+              `varBinds`. Default is `True`.
+            * `ignoreNonIncreasingOid` - continue iteration even if response
+              MIB variables (OIDs) are not greater then request MIB variables.
+              Be aware that setting it to `True` may cause infinite loop between
+              SNMP management and agent applications. Default is `False`.
+            * `maxRows` - stop iteration once this generator instance processed
+              `maxRows` of SNMP conceptual table. Default is `0` (no limit).
+            * `maxCalls` - stop iteration once this generator instance processed
+              `maxCalls` responses. Default is 0 (no limit).
+
+    Yields
+    ------
+    errorIndication : str
+        True value indicates SNMP engine error.
+    errorStatus : str
+        True value indicates SNMP PDU error.
+    errorIndex : int
+        Non-zero value refers to varBinds[errorIndex-1]
+    varBinds : tuple
+        A sequence of :py:class:`~pysnmp.smi.rfc1902.ObjectType` class
+        instances representing MIB variables returned in SNMP response.
+        Contains all valid OIDs from the current GETBULK response batch.
+
+    Raises
+    ------
+    PySnmpError
+        Or its derivative indicating that an error occurred while
+        performing SNMP operation.
+
+    Notes
+    -----
+    Key Behavioral Differences from bulk_walk_cmd:
+
+     - Supports multiple varbinds simultaneously: the generator can walk multiple
+      OID subtrees in parallel within a single SNMP session.
+     - Each varbind is independently tracked: completion, last OID, and
+      lexicographic boundaries are maintained per varbind.
+     - lexicographicMode is applied per-varbind: a varbind stops only when its
+      own scope is exhausted if lexicographicMode=False. Other varbinds continue.
+     - Can optionally ignore non-increasing OIDs: if ignoreNonIncreasingOid=True,
+      the generator continues even when the agent returns OIDs that are not
+      greater than previous ones.
+     - Returns all valid responses from each GETBULK call in a single yield: all
+      active varbinds' results are grouped together in the same batch.
+     - Respects maxRows and maxCalls limits across all varbinds combined.
+     - Handles timeouts gracefully: the generator continues unless the error
+      is non-recoverable.
+
+    Examples
+    --------
+    >>> from pysnmp.hlapi.v3arch.asyncio import *
+    >>> objects = await multi_bulk_walk_cmd(
+    ...     SnmpEngine(),
+    ...     CommunityData('public'),
+    ...     await UdpTransportTarget.create(('demo.pysnmp.com', 161)),
+    ...     ContextData(),
+    ...     0, 25,
+    ...     ObjectType(ObjectIdentity('SNMPv2-MIB', 'sysDescr'))
+    ... )
+    >>> g = [item async for item in objects]
+    >>> next(g)
+    (None, 0, 0, [ObjectType(ObjectIdentity(ObjectName('1.3.6.1.2.1.1.1.0')), DisplayString('SunOS zeus.pysnmp.com 4.1.3_U1 1 sun4m'))])
+    >>> g.send( [ ObjectType(ObjectIdentity('IF-MIB', 'ifInOctets')) ] )
+    (None, 0, 0, [(ObjectName('1.3.6.1.2.1.2.2.1.10.1'), Counter32(284817787))])
+    """
+    lexicographicMode = options.get("lexicographicMode", True)
+    ignoreNonIncreasingOid = options.get("ignoreNonIncreasingOid", False)
+    maxRows = options.get("maxRows", 0)
+    maxCalls = options.get("maxCalls", 0)
+
+    initialVars = [x[0] for x in VB_PROCESSOR.make_varbinds(snmpEngine.cache, varBinds)]
+    num_varbinds = len(initialVars)
+
+    # Track state for each varbind independently
+    completed = [False] * num_varbinds
+
+    # Track last seen OID per varbind (used for next bulk_cmd request)
+    last_oids = [
+        vb[0] if isinstance(vb[0], ObjectIdentity) else ObjectIdentity(vb[0])
+        for vb in varBinds
+    ]
+
+    totalRows = 0
+    totalCalls = 0
+
+    # Continue until all varbinds are exhausted
+    while True:
+
+        valid_results = []
+        if varBinds:
+            # Adjust maxRepetitions if approaching maxRows limit
+            if maxRows and totalRows < maxRows:
+                adjusted_max_reps = min(maxRepetitions, maxRows - totalRows)
+            else:
+                adjusted_max_reps = maxRepetitions
+
+            # Build request varbinds from currently active (non-completed) varbinds
+            active_indices = [i for i in range(num_varbinds) if not completed[i]]
+
+            if not active_indices:
+                # All varbinds have completed their walk
+                return
+
+            # Create request varbinds using last known OIDs for active varbinds
+            request_varbinds = [
+                ObjectType(
+                    (
+                        last_oids[i]
+                        if isinstance(last_oids[i], ObjectIdentity)
+                        else ObjectIdentity(last_oids[i])
+                    ),
+                    Null(""),
+                )
+                for i in active_indices
+            ]
+
+            errorIndication, errorStatus, errorIndex, varBindTable = await bulk_cmd(
+                snmpEngine,
+                authData,
+                transportTarget,
+                contextData,
+                nonRepeaters,
+                adjusted_max_reps,
+                *request_varbinds,
+                **dict(lookupMib=options.get("lookupMib", True)),
+            )
+
+            if (
+                ignoreNonIncreasingOid
+                and errorIndication
+                and isinstance(errorIndication, errind.OidNotIncreasing)
+            ):
+                errorIndication = None
+
+            if errorIndication:
+                yield (
+                    errorIndication,
+                    errorStatus,
+                    errorIndex,
+                    varBindTable and tuple(varBindTable) or (),
+                )
+                if errorIndication != errind.requestTimedOut:
+                    return
+            elif errorStatus:
+                # SNMP PDU errors from agent
+                if errorStatus == 2:
+                    # Hide SNMPv1 noSuchName error which leaks in here
+                    # from SNMPv1 Agent through internal pysnmp proxy
+                    errorStatus = 0
+                    errorIndex = 0
+
+                yield (
+                    errorIndication,
+                    errorStatus,
+                    errorIndex,
+                    tuple(ObjectType(last_oids[i], Null("")) for i in active_indices),
+                )
+                return
+            else:
+                # Successful response - process the varBindTable
+                if not varBindTable:
+                    return
+
+                # Group responses by source varbind
+                # bulk_cmd returns: [vb0_r0, vb1_r0, ..., vbN_r0, vb0_r1, vb1_r1, ...]
+                # Which regroup to: [[vb0_r0, vb0_r1, ...], [vb1_r0, vb1_r1, ...]]
+                num_active = len(active_indices)
+                responses_per_varbind = [[] for _ in range(num_active)]
+
+                for idx, response_vb in enumerate(varBindTable):
+                    active_vb_idx = idx % num_active
+                    responses_per_varbind[active_vb_idx].append(response_vb)
+
+                # Collect all valid responses from this bulk_cmd call
+                stopFlag = True
+
+                for active_idx, original_idx in enumerate(active_indices):
+                    responses = responses_per_varbind[active_idx]
+
+                    if not responses:
+                        completed[original_idx] = True
+                        continue
+
+                    # Track last valid OID for this varbind
+                    last_valid_oid = None
+                    varbind_still_active = False
+
+                    # Process all responses for this varbind
+                    for response_vb in responses:
+                        name, val = response_vb
+                        foundEnding = isinstance(val, Null) or isinstance(
+                            val, EndOfMibView
+                        )
+
+                        # Check if beyond initial scope (when lexicographicMode=False)
+                        foundBeyond = not lexicographicMode and not initialVars[
+                            original_idx
+                        ].isPrefixOf(name)
+
+                        # Check for endOfMibView sentinel
+                        is_end_of_mib_val = val is endOfMibView
+
+                        if foundEnding or foundBeyond or is_end_of_mib_val:
+                            # This response is beyond scope or end - mark varbind as completed and stop processing
+                            completed[original_idx] = True
+                            break
+
+                        # Valid response - add to results
+                        valid_results.append(response_vb)
+                        last_valid_oid = name
+                        varbind_still_active = True
+                        stopFlag = False
+
+                    # Update last OID for next iteration if we have valid responses
+                    if last_valid_oid is not None and varbind_still_active:
+                        last_oids[original_idx] = last_valid_oid
+
+                totalRows += len(valid_results)
+                totalCalls += 1
+
+                # If stopFlag is True, all varbinds have completed
+                if stopFlag:
+                    # Check if we have any final results to yield
+                    if valid_results:
+                        yield (
+                            errorIndication,
+                            errorStatus,
+                            errorIndex,
+                            tuple(valid_results),
+                        )
+                    return
+
+                # If no valid results, stop walking
+                if not valid_results:
+                    return
+
+        else:
+            errorIndication = errorStatus = errorIndex = None
+            varBinds = ()
+
+        # Yield all collected valid varBinds for this batch
+        initialVarBinds: "tuple[ObjectType, ...]|None" = (
+            yield errorIndication,
+            errorStatus,
+            errorIndex,
+            tuple(valid_results),
+        )
+
+        if initialVarBinds:
+            num_new = len(initialVarBinds)
+
+            new_initial_vars = [
+                x[0]
+                for x in VB_PROCESSOR.make_varbinds(snmpEngine.cache, initialVarBinds)
+            ]
+
+            initialVars = new_initial_vars
+            num_varbinds = num_new
+            completed = [False] * num_varbinds
+            last_oids = [vb[0] for vb in initialVarBinds]
+
+        if maxRows and totalRows >= maxRows:
+            return
+
+        if maxCalls and totalCalls >= maxCalls:
+            return
+
+        if all(completed):
             return
 
 

--- a/tests/hlapi/v1arch/asyncio/manager/cmdgen/test_v1arch_v2c_multibulkwalk.py
+++ b/tests/hlapi/v1arch/asyncio/manager/cmdgen/test_v1arch_v2c_multibulkwalk.py
@@ -1,0 +1,258 @@
+import pytest
+
+from pysnmp.proto.errind import RequestTimedOut
+from pysnmp.hlapi.v1arch.asyncio import *
+from tests.agent_context import AGENT_PORT, AgentContextManager
+
+
+@pytest.mark.asyncio
+async def test_v2c_multi_bulk_walk_multiple_subtrees():
+    """
+    Test that multi_bulk_walk_cmd can walk multiple OID trees in parallel
+    and complete independently.
+    """
+    async with AgentContextManager():
+        with SnmpDispatcher() as snmpDispatcher:
+            max_repetitions = 2
+            objects = multi_bulk_walk_cmd(
+                snmpDispatcher,
+                CommunityData("public"),
+                await UdpTransportTarget.create(("localhost", AGENT_PORT)),
+                0,
+                max_repetitions,
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "system")),
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "snmp")),
+                maxRows=20,
+                lexicographicMode=False,
+            )
+
+            count = 0
+            seen_system = False
+            seen_snmp = False
+            async for errorIndication, errorStatus, errorIndex, varBinds in objects:
+                assert errorIndication is None
+                assert errorStatus == 0
+                assert isinstance(varBinds, tuple)
+                assert len(varBinds) > 0
+                for vb in varBinds:
+                    name = vb[0].prettyPrint()
+                    if name.startswith("SNMPv2-MIB::sys"):
+                        seen_system = True
+                    if name.startswith("SNMPv2-MIB::snmp"):
+                        seen_snmp = True
+                count += 1
+
+            assert seen_system and seen_snmp
+            assert count > 0
+
+
+@pytest.mark.asyncio
+async def test_v2c_multi_bulk_walk_lookupmib_false():
+    async with AgentContextManager():
+        with SnmpDispatcher() as snmpDispatcher:
+            count = 0
+            max_repetitions = 2
+            objects = multi_bulk_walk_cmd(
+                snmpDispatcher,
+                CommunityData("public"),
+                await UdpTransportTarget.create(("localhost", AGENT_PORT)),
+                0,
+                max_repetitions,
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "system")),
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "snmp")),
+                lookupMib=False,
+                lexicographicMode=False,
+            )
+
+            async for errorIndication, errorStatus, errorIndex, varBinds in objects:
+                assert errorIndication is None
+                assert errorStatus == 0
+                assert isinstance(varBinds, tuple)
+                count += 1
+                if count >= 5:
+                    break
+
+            assert count >= 3
+
+
+@pytest.mark.asyncio
+async def test_v2c_multi_bulk_walk_lookupmib_true():
+    async with AgentContextManager():
+        with SnmpDispatcher() as snmpDispatcher:
+            count = 0
+            max_repetitions = 1
+            objects = multi_bulk_walk_cmd(
+                snmpDispatcher,
+                CommunityData("public"),
+                await UdpTransportTarget.create(("localhost", AGENT_PORT)),
+                0,
+                max_repetitions,
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "system")),
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "snmp")),
+                lookupMib=True,
+            )
+
+            async for errorIndication, errorStatus, errorIndex, varBinds in objects:
+                assert errorIndication is None
+                assert errorStatus == 0
+                count += 1
+                if count > 5:
+                    break
+
+            assert count > 0
+
+
+@pytest.mark.asyncio
+async def test_v2c_multi_bulk_walk_maxrows_limit():
+    max_rows = 6
+    async with AgentContextManager():
+        with SnmpDispatcher() as snmpDispatcher:
+            total_seen = 0
+            max_repetitions = 2
+            objects = multi_bulk_walk_cmd(
+                snmpDispatcher,
+                CommunityData("public"),
+                await UdpTransportTarget.create(("localhost", AGENT_PORT)),
+                0,
+                max_repetitions,
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "system")),
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "snmp")),
+                lexicographicMode=False,
+                maxRows=max_rows,
+            )
+
+            async for errorIndication, errorStatus, errorIndex, varBinds in objects:
+                assert errorIndication is None
+                assert errorStatus == 0
+                total_seen += len(varBinds)
+
+            assert total_seen == max_rows
+
+
+@pytest.mark.asyncio
+async def test_v2c_multi_bulk_walk_maxcalls_limit():
+    async with AgentContextManager():
+        with SnmpDispatcher() as snmpDispatcher:
+            max_calls = 2
+            call_count = 0
+            max_repetitions = 4
+            objects = multi_bulk_walk_cmd(
+                snmpDispatcher,
+                CommunityData("public"),
+                await UdpTransportTarget.create(("localhost", AGENT_PORT)),
+                0,
+                max_repetitions,
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "system")),
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "snmp")),
+                maxCalls=max_calls,
+                lexicographicMode=False,
+            )
+
+            async for errorIndication, errorStatus, errorIndex, varBinds in objects:
+                call_count += 1
+
+            assert call_count <= max_calls
+
+
+@pytest.mark.asyncio
+async def test_v2c_multi_bulk_walk_maxcalls_with_maxrows_varbinds_count_limit():
+    async with AgentContextManager():
+        with SnmpDispatcher() as snmpDispatcher:
+            max_calls = 2
+            max_rows = 10
+            call_count = 0
+            total_count = 0
+            max_repetitions = 10
+
+            objects = multi_bulk_walk_cmd(
+                snmpDispatcher,
+                CommunityData("public"),
+                await UdpTransportTarget.create(("localhost", AGENT_PORT)),
+                0,
+                max_repetitions,
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "system")),
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "snmp")),
+                maxCalls=max_calls,
+                maxRows=max_rows,
+            )
+
+            async for errorIndication, errorStatus, errorIndex, varBinds in objects:
+                total_count += len(varBinds)
+                call_count += 1
+
+            assert total_count == max_rows
+            assert call_count <= max_calls
+
+
+@pytest.mark.asyncio
+async def test_v2c_multi_bulk_walk_ignore_non_increasing_oid():
+    async with AgentContextManager():
+        with SnmpDispatcher() as snmpDispatcher:
+            max_repetitions = 2
+
+            objects = multi_bulk_walk_cmd(
+                snmpDispatcher,
+                CommunityData("public"),
+                await UdpTransportTarget.create(("localhost", AGENT_PORT)),
+                0,
+                max_repetitions,
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "system")),
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "snmp")),
+                ignoreNonIncreasingOid=True,
+            )
+
+            count = 0
+            async for errorIndication, errorStatus, errorIndex, varBinds in objects:
+                assert errorStatus == 0
+                count += 1
+                if count > 3:
+                    break
+
+            assert count > 0
+
+
+@pytest.mark.asyncio
+async def test_v2c_multi_bulk_walk_0_4_subtree():
+    async with AgentContextManager():
+        with SnmpDispatcher() as snmpDispatcher:
+            index = 0
+            max_repetitions = 4
+            async for (
+                errorIndication,
+                errorStatus,
+                errorIndex,
+                varBinds,
+            ) in multi_bulk_walk_cmd(
+                snmpDispatcher,
+                CommunityData("public"),
+                await UdpTransportTarget.create(("localhost", AGENT_PORT)),
+                0,
+                max_repetitions,
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "snmp")),
+                lexicographicMode=False,
+            ):
+                assert errorIndication is None
+                assert errorStatus == 0
+                assert len(varBinds) == 4
+                if index == 0:
+                    assert varBinds[0][0].prettyPrint() == "SNMPv2-MIB::snmpInPkts.0"
+
+                if index == 1:
+                    assert (
+                        varBinds[0][0].prettyPrint()
+                        == "SNMPv2-MIB::snmpInBadCommunityUses.0"
+                    )
+
+                if index == 26:
+                    assert (
+                        varBinds[0][0].prettyPrint() == "SNMPv2-MIB::snmpSilentDrops.0"
+                    )
+
+                if index == 27:
+                    assert (
+                        varBinds[0][0].prettyPrint() == "SNMPv2-MIB::snmpProxyDrops.0"
+                    )
+
+                index += 1
+
+            assert index > 0

--- a/tests/hlapi/v3arch/asyncio/manager/cmdgen/test_v2c_multibulkwalk.py
+++ b/tests/hlapi/v3arch/asyncio/manager/cmdgen/test_v2c_multibulkwalk.py
@@ -1,0 +1,290 @@
+import pytest
+
+from pysnmp.hlapi.v3arch.asyncio import *
+from pysnmp.proto.errind import RequestTimedOut
+from tests.agent_context import AGENT_PORT, AgentContextManager
+
+
+@pytest.mark.asyncio
+async def test_v2c_multi_bulk_walk_multiple_subtrees():
+    """
+    Test that multi_bulk_walk_cmd can walk multiple OID trees in parallel
+    and complete independently.
+    """
+    async with AgentContextManager():
+        with SnmpEngine() as snmpEngine:
+            # We walk 'system' and 'snmp' subtrees in parallel
+            max_repetitions = 2
+            objects = multi_bulk_walk_cmd(
+                snmpEngine,
+                CommunityData("public"),
+                await UdpTransportTarget.create(("localhost", AGENT_PORT)),
+                ContextData(),
+                0,
+                max_repetitions,
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "system")),
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "snmp")),
+                maxRows=20,
+                lexicographicMode=False,
+            )
+
+            count = 0
+            seen_system = False
+            seen_snmp = False
+            async for errorIndication, errorStatus, errorIndex, varBinds in objects:
+                assert errorIndication is None
+                assert errorStatus == 0
+                assert isinstance(varBinds, tuple)
+                assert len(varBinds) > 0
+                for vb in varBinds:
+                    name = vb[0].prettyPrint()
+                    if name.startswith("SNMPv2-MIB::sys"):
+                        seen_system = True
+                    if name.startswith("SNMPv2-MIB::snmp"):
+                        seen_snmp = True
+                count += 1
+
+            assert seen_system and seen_snmp
+            assert count > 0
+
+
+@pytest.mark.asyncio
+async def test_v2c_multi_bulk_walk_lookupmib_false():
+    async with AgentContextManager():
+        with SnmpEngine() as snmpEngine:
+            count = 0
+            max_repetitions = 2
+            objects = multi_bulk_walk_cmd(
+                snmpEngine,
+                CommunityData("public"),
+                await UdpTransportTarget.create(("localhost", AGENT_PORT)),
+                ContextData(),
+                0,
+                max_repetitions,
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "system")),
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "snmp")),
+                lookupMib=False,
+                lexicographicMode=False,
+            )
+
+            async for errorIndication, errorStatus, errorIndex, varBinds in objects:
+                assert errorIndication is None
+                assert errorStatus == 0
+                assert isinstance(varBinds, tuple)
+                count += 1
+                if count >= 5:
+                    break
+
+            assert count >= 3
+
+
+@pytest.mark.asyncio
+async def test_v2c_multi_bulk_walk_lookupmib_true():
+    async with AgentContextManager():
+        with SnmpEngine() as snmpEngine:
+            count = 0
+            max_repetitions = 1
+            objects = multi_bulk_walk_cmd(
+                snmpEngine,
+                CommunityData("public"),
+                await UdpTransportTarget.create(("localhost", AGENT_PORT)),
+                ContextData(),
+                0,
+                max_repetitions,
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "system")),
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "snmp")),
+                lookupMib=True,
+            )
+
+            async for errorIndication, errorStatus, errorIndex, varBinds in objects:
+                assert errorIndication is None
+                assert errorStatus == 0
+                count += 1
+                if count > 5:
+                    break
+
+            assert count > 0
+
+
+@pytest.mark.asyncio
+async def test_v2c_multi_bulk_walk_maxrows_limit():
+    max_rows = 6
+    async with AgentContextManager():
+        with SnmpEngine() as snmpEngine:
+            total_seen = 0
+            max_repetitions = 2
+            objects = multi_bulk_walk_cmd(
+                snmpEngine,
+                CommunityData("public"),
+                await UdpTransportTarget.create(("localhost", AGENT_PORT)),
+                ContextData(),
+                0,
+                max_repetitions,
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "system")),
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "snmp")),
+                lexicographicMode=False,
+                maxRows=max_rows,
+            )
+
+            async for errorIndication, errorStatus, errorIndex, varBinds in objects:
+                assert errorIndication is None
+                assert errorStatus == 0
+                total_seen += len(varBinds)
+
+            assert total_seen == max_rows
+
+
+@pytest.mark.asyncio
+async def test_v2c_multi_bulk_walk_maxcalls_limit():
+    async with AgentContextManager():
+        with SnmpEngine() as snmpEngine:
+            max_calls = 2
+            call_count = 0
+            max_repetitions = 4
+
+            objects = multi_bulk_walk_cmd(
+                snmpEngine,
+                CommunityData("public"),
+                await UdpTransportTarget.create(("localhost", AGENT_PORT)),
+                ContextData(),
+                0,
+                max_repetitions,
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "system")),
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "snmp")),
+                maxCalls=max_calls,
+                lexicographicMode=False,
+            )
+
+            async for errorIndication, errorStatus, errorIndex, varBinds in objects:
+                call_count += 1
+
+            assert call_count <= max_calls
+
+
+@pytest.mark.asyncio
+async def test_v2c_multi_bulk_walk_maxcalls_with_maxrows_varbinds_count_limit():
+    async with AgentContextManager():
+        with SnmpEngine() as snmpEngine:
+            max_calls = 2
+            max_rows = 10
+            call_count = 0
+            total_count = 0
+            max_repetitions = 10
+
+            objects = multi_bulk_walk_cmd(
+                snmpEngine,
+                CommunityData("public"),
+                await UdpTransportTarget.create(("localhost", AGENT_PORT)),
+                ContextData(),
+                0,
+                max_repetitions,
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "system")),
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "snmp")),
+                maxCalls=max_calls,
+                maxRows=max_rows,
+            )
+
+            async for errorIndication, errorStatus, errorIndex, varBinds in objects:
+                total_count += len(varBinds)
+                call_count += 1
+
+            assert total_count == max_rows
+            assert call_count <= max_calls
+
+
+@pytest.mark.asyncio
+async def test_v2c_multi_bulk_walk_ignore_non_increasing_oid():
+    async with AgentContextManager():
+        with SnmpEngine() as snmpEngine:
+            max_repetitions = 2
+
+            objects = multi_bulk_walk_cmd(
+                snmpEngine,
+                CommunityData("public"),
+                await UdpTransportTarget.create(("localhost", AGENT_PORT)),
+                ContextData(),
+                0,
+                max_repetitions,
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "system")),
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "snmp")),
+                ignoreNonIncreasingOid=True,
+            )
+
+            count = 0
+            async for errorIndication, errorStatus, errorIndex, varBinds in objects:
+                assert errorStatus == 0
+                count += 1
+                if count > 3:
+                    break
+
+            assert count > 0
+
+
+@pytest.mark.asyncio
+async def test_v2c_multi_bulk_walk_0_4_subtree():
+    async with AgentContextManager():
+        with SnmpEngine() as snmpEngine:
+            index = 0
+            max_repetitions = 4
+            async for (
+                errorIndication,
+                errorStatus,
+                errorIndex,
+                varBinds,
+            ) in multi_bulk_walk_cmd(
+                snmpEngine,
+                CommunityData("public"),
+                await UdpTransportTarget.create(("localhost", AGENT_PORT)),
+                ContextData(),
+                0,
+                max_repetitions,
+                ObjectType(ObjectIdentity("SNMPv2-MIB", "snmp")),
+                lexicographicMode=False,
+            ):
+                assert errorIndication is None
+                assert errorStatus == 0
+                assert len(varBinds) == 4
+                if index == 0:
+                    assert varBinds[0][0].prettyPrint() == "SNMPv2-MIB::snmpInPkts.0"
+
+                if index == 1:
+                    assert (
+                        varBinds[0][0].prettyPrint()
+                        == "SNMPv2-MIB::snmpInBadCommunityUses.0"
+                    )
+
+                if index == 26:
+                    assert (
+                        varBinds[0][0].prettyPrint() == "SNMPv2-MIB::snmpSilentDrops.0"
+                    )
+
+                if index == 27:
+                    assert (
+                        varBinds[0][0].prettyPrint() == "SNMPv2-MIB::snmpProxyDrops.0"
+                    )
+
+                index += 1
+
+            assert index > 0
+
+
+@pytest.mark.asyncio
+async def test_v2c_multi_bulk_walk_non_exist():
+    with SnmpEngine() as snmpEngine:
+        objects = multi_bulk_walk_cmd(
+            snmpEngine,
+            CommunityData("public"),
+            await UdpTransportTarget.create(
+                ("localhost", AGENT_PORT),
+                timeout=0.5,
+                retries=0,
+            ),
+            ContextData(),
+            0,
+            1,
+            ObjectType(ObjectIdentity("SNMPv2-MIB", "sysDescr", 0)),
+        )
+
+        async for errorIndication, errorStatus, errorIndex, varBinds in objects:
+            assert isinstance(errorIndication, RequestTimedOut)
+            break


### PR DESCRIPTION
Add `multi_bulk_walk_cmd` for Multi-Varbind SNMP Walking

#### Summary
Introduces `multi_bulk_walk_cmd` to walk multiple OID trees simultaneously with **lexicographic** mode control per varbind.

#### Why?
* `bulk_walk_cmd` supports only a **single varbind** at a time and already includes lexicographic mode handling.
However, to achieve the same behavior for multiple varbinds (from different OID subtrees), each varbind must be walked separately in sequence.
* This leads to multiple SNMP calls and increased total runtime, especially when a maxRows limit or call count constraint is applied on the system.
The new multi_bulk_walk_cmd addresses this by allowing multiple varbinds to be walked in parallel within a single session, maintaining lexicographic consistency while significantly reducing network roundtrips and improving overall efficiency.

#### Key Changes
* Added `multi_bulk_walk_cmd` function for parallel walking of multiple OID subtrees
* Implemented **lexicographic** mode control for each varbind
* Restored _**etingof's**_ `bulkCmd` multi-varbind with lexicographic capability with modern async/await patterns
* Maintained full backward compatibility with single-varbind `bulk_walk_cmd` usage
* Implemented precise `maxRows` handling that counts actual OIDs (not iterations) with automatic truncation
* Added per-varbind completion tracking for independent state management


#### Performance
* With comparing **Etingof’s bulkCmd** (using varbinds=[ObjectType(ObjectIdentity("1.3.6")), ObjectType(ObjectIdentity("1.3.6"))], lexicographicMode=False, max_repetitions=70), we observed a total of 41,710 OIDs retrieved over **20,855 SNMP calls**.
* Using the same configuration and restoring identical lexicographic behavior with the new **multi_bulk_walk_cmd**, the results were 41,708 OIDs retrieved with only **791 SNMP calls**.
* The overall execution time improved by approximately **5–7 seconds** faster under the same test conditions.
* When attempting to parallelize `bulk_walk_cmd` externally (i.e., running processes per OID subtree to simulate concurrency), The overall call count and runtime both increased when max_repetitions was large.
*  for example, when multiple OIDs had only a few sub-OIDs, or when max_repetitions was comparable to the total subtree size. In such cases, the total execution time was observed to be **60–70%** higher compared to multi_bulk_walk_cmd. When running on limited resources, this effect becomes more noticeable, adding extra latency and SNMP calls.