### PR TITLE
fix: Excessive instance identifier sub-OIDs left at MibTableRow error for InetAddressType

### DIFF
--- a/pysnmp/smi/mibs/SNMPv2-SMI.py
+++ b/pysnmp/smi/mibs/SNMPv2-SMI.py
@@ -1298,7 +1298,7 @@ class MibTableRow(MibTree):
                 return obj.clone(tuple(value)), ()
             elif obj.is_fixed_length():
                 fixed_length = obj.get_fixed_length()
-                return obj.clone(tuple(value[:fixed_length])), value[fixed_length:]
+                return obj.clone(tuple(value[1 :fixed_length + 1])), value[fixed_length + 1:]
             else:
                 return obj.clone(tuple(value[1 : value[0] + 1])), value[value[0] + 1 :]
         elif baseTag == self.__oidBaseTag:


### PR DESCRIPTION
This PR fixes the issue where the MIB index parsing caused the following error during OID resolution: [see issue here](https://github.com/lextudio/pysnmp/issues/211)

- Adjusted index slicing for fixed-length string handling: