### PR TITLE
proto/rfc3412: do not crash for statusInformation without errorIndication

### DIFF
--- a/pysnmp/proto/rfc3412.py
+++ b/pysnmp/proto/rfc3412.py
@@ -432,7 +432,7 @@ class MsgAndPduDispatcher:
 
         except error.StatusInformation:
             statusInformation = sys.exc_info()[1]
-            if "sendPduHandle" in statusInformation:  # type: ignore
+            if "sendPduHandle" in statusInformation and "errorIndication" in statusInformation:  # type: ignore
                 # Dropped REPORT -- re-run pending reqs queue as some
                 # of them may be waiting for this REPORT
                 debug.logger & debug.FLAG_DSP and debug.logger(


### PR DESCRIPTION
We have some hardware (Mikrotik RbwAPG-60ad) generating crashes with pysnmp. Full traceback is:
```
ERROR default_exception_handler(): Exception in callback AbstractTransportDispatcher._callback_function()
handle: <Handle AbstractTransportDispatcher._callback_function()>
 Traceback (most recent call last):
   File "pysnmp/proto/rfc3412.py", line 425, in receive_message
     ) = mpHandler.prepare_data_elements(
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
         snmpEngine, transportDomain, transportAddress, wholeMsg
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     )  # type: ignore
     ^
   File "pysnmp/proto/mpmod/rfc3412.py", line 905, in prepare_data_elements
     raise statusInformation
  pysnmp.proto.error.StatusInformation: {'sendPduHandle': 5936909}
 During handling of the above exception, another exception occurred:
 Traceback (most recent call last):
   File "asyncio/events.py", line 89, in _run
     self._context.run(self._callback, *self._args)
     ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "pysnmp/carrier/base.py", line 166, in _callback_function
     self.__recv_callables[recvId](
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
         self, transportDomain, transportAddress, incomingMessage
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     )
     ^
   File "pysnmp/entity/engine.py", line 228, in __receive_message_callback
     self.message_dispatcher.receive_message(
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
         self, transportDomain, transportAddress, wholeMsg
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     )
     ^
   File "pysnmp/proto/rfc3412.py", line 442, in receive_message
     self.__expire_request(
     ~~~~~~~~~~~~~~~~~~~~~^
         statusInformation["sendPduHandle"],  # type: ignore
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ...<2 lines>...
         statusInformation,
         ^^^^^^^^^^^^^^^^^^
     )
     ^
   File "pysnmp/proto/rfc3412.py", line 696, in __expire_request
     processResponsePdu(
     ~~~~~~~~~~~~~~~~~~^
         snmpEngine,
         ^^^^^^^^^^^
     ...<10 lines>...
         cachedParams["cbCtx"],
         ^^^^^^^^^^^^^^^^^^^^^^
     )
     ^
   File "pysnmp/entity/rfc3413/cmdgen.py", line 78, in process_response_pdu
     errorIndication = statusInformation["errorIndication"]
                       ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
   File "pysnmp/proto/error.py", line 44, in __getitem__
     return self.__errorIndication[key]
            ~~~~~~~~~~~~~~~~~~~~~~^^^^^
 KeyError: 'errorIndication'
```
Packets generating this traceback are class INTERNAL_CLASS_PDUS, without varBinds, and matching rule 7.2.11e from RFC 3412.

Current code is raising a statusInformation without errorIndication, since RFC says:
```
       e) A SUCCESS result is returned.  SNMPv3 Message Processing is
          complete.
```
This patch avoid the crash, we don't need to call __expire_request when we receive this kind of packets.