### PR TITLE
fix: handle missing errorIndication in StatusInformation

### DIFF
--- a/pysnmp/entity/rfc3413/cmdgen.py
+++ b/pysnmp/entity/rfc3413/cmdgen.py
@@ -75,7 +75,9 @@ class CommandGenerator:
                 f"processResponsePdu: sendPduHandle {sendPduHandle}, statusInformation {statusInformation}"
             )
 
-            errorIndication = statusInformation["errorIndication"]
+            errorIndication = statusInformation.get(
+                "errorIndication", errind.requestTimedOut
+            )
 
             if errorIndication in (errind.notInTimeWindow, errind.unknownEngineID):
                 origDiscoveryRetries += 1
@@ -152,7 +154,7 @@ class CommandGenerator:
                 cbFun(
                     snmpEngine,
                     origSendRequestHandle,
-                    statusInformation["errorIndication"],  # type: ignore
+                    statusInformation.get("errorIndication", errind.requestTimedOut),  # type: ignore
                     None,
                     cbCtx,
                 )


### PR DESCRIPTION
Fixes #241

`rfc3412.prepare_data_elements` can raise a `StatusInformation` with only `sendPduHandle` and no `errorIndication` key (line 875 in rfc3412.py, the else-branch when `reportableFlag` is false). When `cmdgen.process_response_pdu` catches this, it does `statusInformation["errorIndication"]` which throws a `KeyError`.

Switched both lookups in `cmdgen.py` to `.get("errorIndication", errind.requestTimedOut)` so the callback still fires with a sensible error instead of crashing.

-- saschabuehrle