### PR TITLE
fix: decode InetAddress index when InetAddressType is unknown(0)

### DIFF
--- a/pysnmp/smi/mibs/INET-ADDRESS-MIB.py
+++ b/pysnmp/smi/mibs/INET-ADDRESS-MIB.py
@@ -228,10 +228,26 @@ class InetAddress(TextualConvention, OctetString):
         InetAddressType.namedValues.getValue("dns"): InetAddressDNS(),
     }
 
+    # RFC 4001 defines no textual convention for unknown(0), because the paired
+    # InetAddress is always zero-length. typeMap therefore has no entry for it,
+    # so it has to be handled explicitly: a missing entry must not be treated as
+    # "wrong index column", or a row carrying more than one
+    # InetAddressType/InetAddress pair (e.g. inetCidrRouteEntry) would fall
+    # through to an unrelated type column.
+    unknownAddressType = InetAddressType.namedValues.getValue("unknown")
+
     @classmethod
     def clone_from_name(cls, value, impliedFlag, parentRow, parentIndices):
         for parentIndex in reversed(parentIndices):
             if isinstance(parentIndex, InetAddressType):
+                if int(parentIndex) == cls.unknownAddressType:
+                    # unknown(0) is encoded as a single length sub-identifier of
+                    # 0 and carries no address octets.
+                    if impliedFlag:
+                        return cls(""), value
+                    length = value[0]
+                    return cls(tuple(value[1 : 1 + length])), value[1 + length :]
+
                 try:
                     specific = cls.typeMap[int(parentIndex)]
                 except KeyError:
@@ -253,6 +269,13 @@ class InetAddress(TextualConvention, OctetString):
     def clone_as_name(self, impliedFlag, parentRow, parentIndices):
         for parentIndex in reversed(parentIndices):
             if isinstance(parentIndex, InetAddressType):
+                if int(parentIndex) == self.unknownAddressType:
+                    # unknown(0) carries no address octets; emit just the
+                    # zero length prefix (or nothing at all when implied).
+                    if impliedFlag:
+                        return self.asNumbers()
+                    return (len(self),) + self.asNumbers()
+
                 try:
                     typed_obj = self.typeMap[int(parentIndex)].clone(self.asOctets())
                     # InetAddress always uses length-prefix encoding in OIDs (RFC 4001).

--- a/tests/smi/test_inetaddress_index.py
+++ b/tests/smi/test_inetaddress_index.py
@@ -82,3 +82,105 @@ def test_inetaddress_length_prefixed_index_is_parsed_correctly(
 
     assert indices[0].prettyPrint() == expected_type
     assert indices[1].prettyPrint() == expected_address
+
+
+def _make_dual_inet_address_row(mibBuilder):
+    """Build a row shaped like inetCidrRouteEntry, which indexes on *two*
+    InetAddressType/InetAddress pairs (dest and next hop).
+    """
+    (MibTableRow, MibTableColumn) = mibBuilder.import_symbols(
+        "SNMPv2-SMI", "MibTableRow", "MibTableColumn"
+    )
+    (InetAddressType, InetAddress) = mibBuilder.import_symbols(
+        "INET-ADDRESS-MIB", "InetAddressType", "InetAddress"
+    )
+    (Integer32,) = mibBuilder.import_symbols("SNMPv2-SMI", "Integer32")
+    from pyasn1.type.univ import ObjectIdentifier
+
+    base = (1, 3, 6, 1, 2, 1, 4, 24, 7, 1)
+    columns = {
+        "cidrRouteDestType": MibTableColumn(base + (1,), InetAddressType()),
+        "cidrRouteDest": MibTableColumn(base + (2,), InetAddress()),
+        "cidrRoutePfxLen": MibTableColumn(base + (3,), Integer32()),
+        "cidrRoutePolicy": MibTableColumn(base + (4,), ObjectIdentifier()),
+        "cidrRouteNextHopType": MibTableColumn(base + (5,), InetAddressType()),
+        "cidrRouteNextHop": MibTableColumn(base + (6,), InetAddress()),
+    }
+    mibBuilder.export_symbols("TEST-INET-CIDR-ROUTE", **columns)
+
+    row = MibTableRow(base)
+    row.indexNames = tuple((False, "TEST-INET-CIDR-ROUTE", name) for name in columns)
+    return row
+
+
+def test_inetaddress_unknown_type_decodes_as_zero_length_address():
+    """Regression test for issue #247.
+
+    An InetAddressType of unknown(0) has no INET-ADDRESS-MIB textual convention,
+    because the paired address is always zero-length. The type lookup must not
+    treat that as "wrong index column" and scan past it, or a row with two
+    InetAddressType columns decodes the next hop against the *destination* type.
+    """
+    mibBuilder = _load_mib_builder()
+    row = _make_dual_inet_address_row(mibBuilder)
+
+    # ipv6 destination ff00::/8, next hop type unknown(0) with an empty address.
+    inst_id = (
+        2,
+        16,
+        255,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        8,
+        2,
+        0,
+        0,
+        0,
+        0,
+    )
+
+    indices = row.getIndicesFromInstId(inst_id)
+
+    assert len(indices) == 6
+    assert indices[0].prettyPrint() == "ipv6"
+    assert indices[1].prettyPrint() == "ff00:00:00:00:00:00:00:00"
+    assert indices[2].prettyPrint() == "8"
+    assert indices[4].prettyPrint() == "unknown"
+    assert indices[5].prettyPrint() == ""
+    assert len(indices[5]) == 0
+
+
+def test_inetaddress_unknown_type_encodes_back_to_zero_length_prefix():
+    """The encode path must be symmetric: unknown(0) emits just a 0 length."""
+    mibBuilder = _load_mib_builder()
+    row = _make_dual_inet_address_row(mibBuilder)
+    (InetAddressType, InetAddress) = mibBuilder.import_symbols(
+        "INET-ADDRESS-MIB", "InetAddressType", "InetAddress"
+    )
+    (Integer32,) = mibBuilder.import_symbols("SNMPv2-SMI", "Integer32")
+    from pyasn1.type.univ import ObjectIdentifier
+
+    parent_indices = [
+        InetAddressType(2),  # destination type: ipv6
+        InetAddress(""),
+        Integer32(8),
+        ObjectIdentifier("0.0"),
+        InetAddressType(0),  # next hop type: unknown -- the nearest one
+    ]
+
+    encoded = InetAddress("").clone_as_name(False, row, parent_indices)
+
+    assert encoded == (0,)


### PR DESCRIPTION
Fixes #247.

## The bug

`InetAddressType = unknown(0)` has no entry in `InetAddress.typeMap`, because RFC 4001 defines no textual convention for it — the paired address is always zero-length.

Both `clone_from_name` and `clone_as_name` treated that missing entry as *"this isn't the index column I'm looking for"* and continued scanning `parentIndices`:

```python
try:
    specific = cls.typeMap[int(parentIndex)]
except KeyError:
    continue          # keeps scanning past the governing index
```

That is only safe when a row has a single `InetAddressType`. `inetCidrRouteEntry` has **two** (`inetCidrRouteDestType` and `inetCidrRouteNextHopType`), so when decoding `inetCidrRouteNextHop` the loop skipped past `unknown(0)` and landed on the *destination* type instead. Agents emit such rows for routes with no next hop — blackhole, directly connected, multicast/reserved prefixes.

Decoding collapsed to `((0,),)`, and the encode direction raised `ValueConstraintError` trying to clone an empty address as `InetAddressIPv6`.

This is not the length-prefix issue from #238 — that fix is present and the IPv4/IPv6 vectors from it still decode correctly (both are kept as controls in the tests).

## The fix

Handle `unknown(0)` explicitly in both directions, before the `typeMap` lookup:

- **decode** — consume the length prefix (`0`) and return a zero-length `InetAddress`
- **encode** — emit a bare `0` length sub-identifier and no address octets

The change is **purely additive** (125 insertions, 0 deletions). No existing branch is modified: the `except KeyError: continue` fall-through is left exactly as it was. Worth noting it is now unreachable for every value RFC 4001 defines — `typeMap` covers `ipv4`/`ipv6`/`ipv4z`/`ipv6z`/`dns` and `unknown(0)` is handled above it — so it could be tightened into an explicit error separately if you'd prefer; I left it alone to keep this diff to the reported bug.

## Verification

Repro from the issue, before → after:

```
=== unknown(0) nexthop ===
  UNDECODED -> ((0,),)                    # before

  destType : 'ipv6'                       # after
  dest     : 'ff00:00:00:00:00:00:00:00'
  pfxLen   : '8'
  policy   : '0.0'
  nhType   : 'unknown'
  nextHop  : ''
```

which matches the expected output in the issue exactly.

**Tests** — two regression tests added to `tests/smi/test_inetaddress_index.py`, built on a row shaped like `inetCidrRouteEntry` (two `InetAddressType`/`InetAddress` pairs), covering decode and the encode round-trip. Both **fail on the unfixed source** and pass with the change:

```
# new tests against unfixed source
FAILED test_inetaddress_unknown_type_decodes_as_zero_length_address
FAILED test_inetaddress_unknown_type_encodes_back_to_zero_length_prefix
2 failed, 2 passed

# with the fix
4 passed
```

**No regressions** — `tests/smi/` + `tests/proto/` give an identical pass/fail set before and after the change (`3 failed, 45 passed` both ways; the 3 failures are pre-existing and unrelated to `InetAddress`). All 13 InetAddress tests pass.

`ruff check` and `ruff format --check` are clean on both files.
